### PR TITLE
fix: Update COPY command to use correct path for proxy

### DIFF
--- a/archive/proxy/Dockerfile
+++ b/archive/proxy/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /app
 COPY --from=builder /root/.local /root/.local
 
 # Copy application code
-COPY proxy/ .
+COPY archive/proxy/ .
 
 # Make sure scripts in .local are usable
 ENV PATH=/root/.local/bin:$PATH


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process for the proxy service. The change ensures that the correct directory is copied into the Docker image.

* Dockerfile update: The `COPY` instruction now uses `archive/proxy/` instead of `proxy/`, ensuring the correct application code is included in the build.