### PR TITLE
fix: Update Dockerfile to copy requirements from correct path

### DIFF
--- a/archive/proxy/Dockerfile
+++ b/archive/proxy/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # Copy only requirements first for better caching
-COPY proxy/requirements.txt .
+COPY archive/proxy/requirements.txt .
 
 # Install Python dependencies
 RUN pip install --no-cache-dir --user -r requirements.txt


### PR DESCRIPTION
This pull request updates the Docker build process for the proxy service by correcting the path to the requirements file. This ensures that the correct dependencies are installed during the image build.

* Dockerfile update: Changed the path in the `COPY` command from `proxy/requirements.txt` to `archive/proxy/requirements.txt` in `archive/proxy/Dockerfile`, ensuring the correct requirements file is used for dependency installation.