### PR TITLE
feat: Add refresh trigger env for containerapps

### DIFF
--- a/src/llmaven/infrastructure/resources/container_apps.py
+++ b/src/llmaven/infrastructure/resources/container_apps.py
@@ -5,6 +5,7 @@ VNet integration, monitoring, and workload profiles.
 """
 
 from typing import Dict, Optional
+import datetime
 
 import pulumi
 import pulumi_azure_native as azure_native
@@ -154,6 +155,14 @@ def create_container_app_with_key_vault_secrets(
     """
     # Build environment variables list
     env_list = []
+
+    # Add refresh trigger environment variable
+    env_list.append(
+        azure_native.app.EnvironmentVarArgs(
+            name="REFRESH_TRIGGER",
+            value=datetime.datetime.utcnow().isoformat(),
+        )
+    )
 
     # Add non-sensitive environment variables
     if env_vars:


### PR DESCRIPTION
This pull request introduces a small but important update to the container app deployment logic. The main change is the addition of a `REFRESH_TRIGGER` environment variable, which uses the current UTC timestamp to help trigger refreshes or restarts of the container app when its configuration changes.

Environment variable update:

* Added a `REFRESH_TRIGGER` environment variable to the container app environment, set to the current UTC timestamp using `datetime.datetime.utcnow().isoformat()`. This can be used to force a refresh or redeployment when the container configuration is updated.

Dependency update:

* Imported the `datetime` module in `src/llmaven/infrastructure/resources/container_apps.py` to support the new environment variable.