### PR TITLE
chore: Update litellm to v1.81.0-stable

### DIFF
--- a/docker/dockerfiles/litellm.dockerfile
+++ b/docker/dockerfiles/litellm.dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/berriai/litellm:v1.79.1-stable
+FROM ghcr.io/berriai/litellm:v1.81.0-stable
 
 RUN pip install --no-cache-dir "mlflow==3.6.0"


### PR DESCRIPTION
Updated the litellm base image version to the latest stable version
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update base image in `litellm.dockerfile` to `v1.81.0-stable`.
> 
>   - **Dockerfile Update**:
>     - Update base image in `litellm.dockerfile` from `v1.79.1-stable` to `v1.81.0-stable`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=uw-ssec%2Fllmaven&utm_source=github&utm_medium=referral)<sup> for b1fc85b1fdafa6b7c0880dad079d420c83df3ce4. You can [customize](https://app.ellipsis.dev/uw-ssec/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->