### PR TITLE
Update LiteLLM base image to version 1.82.3

### DIFF
--- a/docker/dockerfiles/litellm.dockerfile
+++ b/docker/dockerfiles/litellm.dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/berriai/litellm:v1.81.0-stable
+FROM ghcr.io/berriai/litellm:v1.82.3-stable
 
 RUN pip install --no-cache-dir "mlflow==3.6.0"


### PR DESCRIPTION
This pull request updates the LiteLLM Docker image to use a newer stable version. This ensures the environment has the latest features and security updates.

- **Dependency update:**
  * [`docker/dockerfiles/litellm.dockerfile`](diffhunk://#diff-e932ed0b5a440abd98e4edac45bf7874bf9751e11207009bc6dbd4e797658172L1-R1): Updated the LiteLLM base image from version `v1.81.0-stable` to `v1.82.3-stable`.