### PR TITLE
fix: enforce env_file validation consistently across infra commands (#90)

### DIFF
--- a/src/llmaven/cli.py
+++ b/src/llmaven/cli.py
@@ -52,6 +52,22 @@ agentic_app = typer.Typer(
 app.add_typer(agentic_app)
 
 
+# Shared --env-file option: enforces consistent Typer Path validation
+# across `infra validate`, `infra deploy`, and `infra extract`.
+ENV_FILE_OPTION = typer.Option(
+    None,
+    "--env-file",
+    "-e",
+    help="Path to .env file containing LLMAVEN_SECRETS_* variables",
+    exists=True,
+    dir_okay=False,
+    file_okay=True,
+    readable=True,
+    resolve_path=True,
+    path_type=Path,
+)
+
+
 class Environment(str, Enum):
     """Environment modes for the server."""
 
@@ -340,18 +356,7 @@ def validate(
         is_flag=True,
         help="Skip secrets validation (use with caution)",
     ),
-    env_file: Optional[Path] = typer.Option(
-        None,
-        "--env-file",
-        "-e",
-        help="Path to .env file containing LLMAVEN_SECRETS_* variables",
-        exists=True,
-        dir_okay=False,
-        file_okay=True,
-        readable=True,
-        resolve_path=True,
-        path_type=Path,
-    ),
+    env_file: Optional[Path] = ENV_FILE_OPTION,
 ) -> None:
     """Validate LLMaven deployment configuration.
 
@@ -417,18 +422,7 @@ def deploy(
         is_flag=True,
         help="Automatically approve deployment",
     ),
-    env_file: Optional[Path] = typer.Option(
-        None,
-        "--env-file",
-        "-e",
-        help="Path to .env file containing LLMAVEN_SECRETS_* variables",
-        exists=True,
-        dir_okay=False,
-        file_okay=True,
-        readable=True,
-        resolve_path=True,
-        path_type=Path,
-    ),
+    env_file: Optional[Path] = ENV_FILE_OPTION,
 ) -> None:
     """Deploy LLMaven infrastructure to Azure.
 
@@ -1016,18 +1010,7 @@ def extract(
         resolve_path=True,
         path_type=Path,
     ),
-    env_file: Optional[Path] = typer.Option(
-        None,
-        "--env-file",
-        "-e",
-        help="Path to .env file containing LLMAVEN_SECRETS_* variables",
-        exists=True,
-        dir_okay=False,
-        file_okay=True,
-        readable=True,
-        resolve_path=True,
-        path_type=Path,
-    ),
+    env_file: Optional[Path] = ENV_FILE_OPTION,
 ) -> None:
     """Extract source logs/traces into a day-partitioned JSONL zip.
 

--- a/src/llmaven/cli.py
+++ b/src/llmaven/cli.py
@@ -340,11 +340,17 @@ def validate(
         is_flag=True,
         help="Skip secrets validation (use with caution)",
     ),
-    env_file: Optional[str] = typer.Option(
+    env_file: Optional[Path] = typer.Option(
         None,
         "--env-file",
         "-e",
         help="Path to .env file containing LLMAVEN_SECRETS_* variables",
+        exists=True,
+        dir_okay=False,
+        file_okay=True,
+        readable=True,
+        resolve_path=True,
+        path_type=Path,
     ),
 ) -> None:
     """Validate LLMaven deployment configuration.
@@ -374,14 +380,13 @@ def validate(
     from llmaven.deployment.validate import ValidationError, validate_config
 
     config_path = Path(config) if config else Path("llmaven-config.yaml")
-    env_file_path = Path(env_file) if env_file else None
 
     try:
         validate_config(
             config_path=config_path,
             strict=strict,
             skip_secrets=skip_secrets,
-            env_file_path=env_file_path,
+            env_file_path=env_file,
         )
     except ValidationError:
         sys.exit(1)
@@ -412,11 +417,17 @@ def deploy(
         is_flag=True,
         help="Automatically approve deployment",
     ),
-    env_file: Optional[str] = typer.Option(
+    env_file: Optional[Path] = typer.Option(
         None,
         "--env-file",
         "-e",
         help="Path to .env file containing LLMAVEN_SECRETS_* variables",
+        exists=True,
+        dir_okay=False,
+        file_okay=True,
+        readable=True,
+        resolve_path=True,
+        path_type=Path,
     ),
 ) -> None:
     """Deploy LLMaven infrastructure to Azure.
@@ -442,14 +453,13 @@ def deploy(
     from llmaven.deployment.deploy import DeploymentError, deploy_infrastructure
 
     config_path = Path(config) if config else Path("llmaven-config.yaml")
-    env_file_path = Path(env_file) if env_file else None
 
     try:
         deploy_infrastructure(
             config_path=config_path,
             preview=preview,
             auto_approve=auto_approve,
-            env_file_path=env_file_path,
+            env_file_path=env_file,
         )
     except DeploymentError as e:
         typer.echo(f"✗ Deployment failed: {e}", err=True)
@@ -1006,7 +1016,6 @@ def extract(
         resolve_path=True,
         path_type=Path,
     ),
-    # TODO: enforce env_file rules specified below in similar parameter definitions in this file (https://github.com/uw-ssec/llmaven/issues/90).
     env_file: Optional[Path] = typer.Option(
         None,
         "--env-file",

--- a/tests/infrastructure/test_cli_env_file_validation.py
+++ b/tests/infrastructure/test_cli_env_file_validation.py
@@ -1,0 +1,146 @@
+"""CLI tests for --env-file parameter validation (issue #90).
+
+Ensures `llmaven infra validate` and `llmaven infra deploy` apply the same
+Typer-level validation rules that were introduced for `llmaven infra extract`
+in PR #79 (exists, file_okay, dir_okay=False, readable, resolve_path).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from llmaven.cli import app
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestInfraValidateEnvFile:
+    def test_rejects_missing_env_file(self, runner: CliRunner, tmp_path: Path):
+        missing = tmp_path / "does-not-exist.env"
+
+        result = runner.invoke(
+            app,
+            ["infra", "validate", "--env-file", str(missing)],
+        )
+
+        assert result.exit_code == 2
+        assert "Invalid value for '--env-file'" in result.output
+
+    def test_rejects_env_file_that_is_a_directory(
+        self, runner: CliRunner, tmp_path: Path
+    ):
+        dir_path = tmp_path / "a-dir"
+        dir_path.mkdir()
+
+        result = runner.invoke(
+            app,
+            ["infra", "validate", "--env-file", str(dir_path)],
+        )
+
+        assert result.exit_code == 2
+        assert "Invalid value for '--env-file'" in result.output
+
+    @patch("llmaven.deployment.validate.validate_config")
+    def test_accepts_valid_env_file_and_passes_path_through(
+        self,
+        mock_validate_config,
+        runner: CliRunner,
+        tmp_path: Path,
+    ):
+        env_file = tmp_path / ".env.secrets"
+        env_file.write_text("LLMAVEN_SECRETS_FOO=bar\n", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["infra", "validate", "--env-file", str(env_file)],
+        )
+
+        assert result.exit_code == 0
+        mock_validate_config.assert_called_once()
+
+        kwargs = mock_validate_config.call_args.kwargs
+        assert isinstance(kwargs["env_file_path"], Path)
+        # resolve_path=True means the path is resolved to absolute form.
+        assert kwargs["env_file_path"] == env_file.resolve()
+
+    @patch("llmaven.deployment.validate.validate_config")
+    def test_env_file_defaults_to_none(
+        self,
+        mock_validate_config,
+        runner: CliRunner,
+    ):
+        with runner.isolated_filesystem():
+            Path("llmaven-config.yaml").write_text("project: {}\n", encoding="utf-8")
+            result = runner.invoke(app, ["infra", "validate"])
+
+        assert result.exit_code == 0
+        kwargs = mock_validate_config.call_args.kwargs
+        assert kwargs["env_file_path"] is None
+
+
+class TestInfraDeployEnvFile:
+    def test_rejects_missing_env_file(self, runner: CliRunner, tmp_path: Path):
+        missing = tmp_path / "does-not-exist.env"
+
+        result = runner.invoke(
+            app,
+            ["infra", "deploy", "--yes", "--env-file", str(missing)],
+        )
+
+        assert result.exit_code == 2
+        assert "Invalid value for '--env-file'" in result.output
+
+    def test_rejects_env_file_that_is_a_directory(
+        self, runner: CliRunner, tmp_path: Path
+    ):
+        dir_path = tmp_path / "a-dir"
+        dir_path.mkdir()
+
+        result = runner.invoke(
+            app,
+            ["infra", "deploy", "--yes", "--env-file", str(dir_path)],
+        )
+
+        assert result.exit_code == 2
+        assert "Invalid value for '--env-file'" in result.output
+
+    @patch("llmaven.deployment.deploy.deploy_infrastructure")
+    def test_accepts_valid_env_file_and_passes_path_through(
+        self,
+        mock_deploy,
+        runner: CliRunner,
+        tmp_path: Path,
+    ):
+        env_file = tmp_path / ".env.secrets"
+        env_file.write_text("LLMAVEN_SECRETS_FOO=bar\n", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["infra", "deploy", "--yes", "--env-file", str(env_file)],
+        )
+
+        assert result.exit_code == 0
+        mock_deploy.assert_called_once()
+
+        kwargs = mock_deploy.call_args.kwargs
+        assert isinstance(kwargs["env_file_path"], Path)
+        assert kwargs["env_file_path"] == env_file.resolve()
+
+    @patch("llmaven.deployment.deploy.deploy_infrastructure")
+    def test_env_file_defaults_to_none(
+        self,
+        mock_deploy,
+        runner: CliRunner,
+    ):
+        result = runner.invoke(app, ["infra", "deploy", "--yes"])
+
+        assert result.exit_code == 0
+        kwargs = mock_deploy.call_args.kwargs
+        assert kwargs["env_file_path"] is None


### PR DESCRIPTION
Applies the Typer `env_file` validation pattern introduced for `infra extract`
  in #79 to `infra validate` and `infra deploy`:

  - `exists=True`, `file_okay=True`, `dir_okay=False`, `readable=True`, `resolve_path=True`, `path_type=Path`

  Also removes the TODO marker on `extract` that pointed at this issue.

  ### Tests
  Adds `tests/infrastructure/test_cli_env_file_validation.py` covering, for both commands:
  - missing file → Typer rejects with exit code 2
  - path is a directory → Typer rejects
  - valid file → resolved `Path` passed through to the backing function
  - `None` default still works