### PR TITLE
feat: Secondary backups

### DIFF
--- a/.github/workflows/build-services.yml
+++ b/.github/workflows/build-services.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "docker/**"
+      - "scripts/backup_postgres.py"
       - ".github/workflows/build-services.yml"
   release:
     types: [published]
@@ -27,8 +28,13 @@ jobs:
         service:
           - name: mlflow
             dockerfile: mlflow.dockerfile
+            context: ./docker
           - name: litellm
             dockerfile: litellm.dockerfile
+            context: ./docker
+          - name: backup
+            dockerfile: backup.dockerfile
+            context: .
 
     steps:
       - name: Checkout repository
@@ -62,7 +68,7 @@ jobs:
       - name: Build and push ${{ matrix.service.name }} image
         uses: docker/build-push-action@v7
         with:
-          context: ./docker
+          context: ${{ matrix.service.context }}
           file: ./docker/dockerfiles/${{ matrix.service.dockerfile }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -84,6 +90,7 @@ jobs:
           echo "### Images Built" >> $GITHUB_STEP_SUMMARY
           echo "- 🐳 MLflow: \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-mlflow\`" >> $GITHUB_STEP_SUMMARY
           echo "- 🐳 LiteLLM: \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-litellm\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 🐳 Backup: \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backup\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Registry" >> $GITHUB_STEP_SUMMARY
           echo "Images are available at: [\`${{ env.REGISTRY }}/${{ github.repository }}\`](https://${{ env.REGISTRY }}/${{ github.repository }})" >> $GITHUB_STEP_SUMMARY
@@ -92,4 +99,5 @@ jobs:
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-mlflow:latest" >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-litellm:latest" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backup:latest" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/docker/dockerfiles/backup.dockerfile
+++ b/docker/dockerfiles/backup.dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir fsspec adlfs pyyaml
+
+WORKDIR /app
+COPY scripts/backup_postgres.py .
+
+ENTRYPOINT ["python", "backup_postgres.py"]

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,5 +1,232 @@
 version: 6
 environments:
+  backup:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/pytorch/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adlfs-2026.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/amqp-5.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.41.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/azure-identity-1.25.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/azure-storage-blob-12.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/billiard-4.2.4-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/celery-5.5.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-didyoumean-0.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-48.0.0-py312ha4b625e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.13-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.1.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kombu-5.5.4-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.12.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgirepository-1.86.0-hac26d07_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.61-h54a6638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsecret-0.21.7-h1e2da66_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/msal-1.36.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msal_extensions-1.3.1-py312h7900ff3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-3.2.0-py312h7900ff3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py312h2596900_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pygobject-3.56.3-py312h4785a91_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/vine-5.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.23.0-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adlfs-2026.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.5-py312h9f8c436_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/amqp-5.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.41.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/azure-identity-1.25.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/azure-storage-blob-12.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.5.0-py312h87c4bb7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/billiard-4.2.4-py312h4409184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312h0dfefe5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-he0f2337_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/celery-5.5.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-didyoumean-0.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-48.0.0-py312h1238841_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.17.1-h2b252f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.13-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.1.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kombu-5.5.4-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.5-h55c6f16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.0-hf6b4638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcrypt-lib-1.12.1-h84a0fba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgirepository-1.86.0-h8c9ecdb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgpg-error-1.61-h784d473_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsecret-0.21.7-h6e2beb0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py312h04c11ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/msal-1.36.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msal_extensions-1.3.1-py312h81bd7bf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py312h43af8aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portalocker-3.2.0-py312h81bd7bf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycairo-1.29.0-py312h2437029_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pygobject-3.56.3-py312h189c030_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/vine-5.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.23.0-py312h04c11ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2133,6 +2360,20 @@ packages:
   - rich ; extra == 'dev'
   - sagemaker ; extra == 'sagemaker'
   requires_python: '>=3.10.0'
+- conda: https://conda.anaconda.org/conda-forge/noarch/adlfs-2026.5.0-pyhd8ed1ab_0.conda
+  sha256: 8fe609bbf2b5ac2b2cd0de0eb392bbf25793665ec1aef446da2dde0417d83c8d
+  md5: 7ffaab99fb3f225ea74ba52df5af141b
+  depends:
+  - aiohttp >=3.7.0
+  - azure-core >=1.28.0,<2.0.0
+  - azure-identity
+  - azure-storage-blob >=12.17.0
+  - fsspec >=2023.12.0
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 44484
+  timestamp: 1778546975841
 - pypi: https://files.pythonhosted.org/packages/cd/9f/b833c1ab1999da35ebad54841ae85d2c2764c931da9a6f52d8541b6901b2/ag_ui_protocol-0.1.13-py3-none-any.whl
   name: ag-ui-protocol
   version: 0.1.13
@@ -2245,6 +2486,25 @@ packages:
   license_family: Apache
   size: 1025327
   timestamp: 1767524683938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
+  sha256: 52f4d07b10fe4a1ded570b0708594d2d9075223e1dd94d0c5988eb71f724a5f2
+  md5: 68edaee7692efb8bbef5e95375090189
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aiohappyeyeballs >=2.5.0
+  - aiosignal >=1.4.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - libgcc >=14
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 1034187
+  timestamp: 1775000054521
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.3-py311h6771f6e_0.conda
   sha256: 1ed398d29af3a63808730a402ee78683b183a8dc3438078e6c5c706e63332855
   md5: a0656f0447843f80851254a94aecd2f8
@@ -2264,6 +2524,25 @@ packages:
   license_family: Apache
   size: 993194
   timestamp: 1767525030810
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.5-py312h9f8c436_0.conda
+  sha256: 11b13962c9c9a4edc831876f448a908ca6b62cf3f71bd5f0f33387f4d8a7955c
+  md5: 99fe4bfba47fd1304c087922a3d0e0f8
+  depends:
+  - __osx >=11.0
+  - aiohappyeyeballs >=2.5.0
+  - aiosignal >=1.4.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 1001884
+  timestamp: 1774999993903
 - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
   name: aiosignal
   version: 1.4.0
@@ -2597,6 +2876,16 @@ packages:
   - pkg:pypi/attrs?source=compressed-mapping
   size: 64759
   timestamp: 1764875182184
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+  sha256: 1b6124230bb4e571b1b9401537ecff575b7b109cc3a21ee019f65e083b8399ab
+  md5: c6b0543676ecb1fb2d7643941fe375f2
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 64927
+  timestamp: 1773935801332
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.1-h536185d_1.conda
   sha256: 3d5a91edc5410aa90ef872a11209ff67bb5406a1785a22580b452c84b833892a
   md5: bc645a385e91cd3d9235174fcbd17e25
@@ -2950,6 +3239,19 @@ packages:
   - pkg:pypi/azure-core?source=compressed-mapping
   size: 117885
   timestamp: 1773360381995
+- conda: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.41.0-pyhd8ed1ab_0.conda
+  sha256: fc46c9078396a558e42871e111c1bf88d3bb16afd4cf8f9887125f83b647cea9
+  md5: 3d743fce13d22b101bfd733e29469628
+  depends:
+  - flask 2.2.5
+  - python >=3.10
+  - requests >=2.21.0
+  - six >=1.11.0
+  - typing_extensions >=4.6.0
+  license: MIT
+  license_family: MIT
+  size: 120143
+  timestamp: 1778202273942
 - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.16.2-h206d751_0.conda
   sha256: 321d1070905e467b6bc6f5067b97c1868d7345c272add82b82e08a0224e326f0
   md5: 5492abf806c45298ae642831c670bba0
@@ -3165,6 +3467,18 @@ packages:
   - pkg:pypi/backports-zstd?source=hash-mapping
   size: 237970
   timestamp: 1767045004512
+- conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
+  sha256: a2b08a4e5e549b5f67c38edffd175437e2208547a7e67b5fa5373b67ef419e50
+  md5: b31dba71fe091e7201826e57e0f7b261
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  size: 239928
+  timestamp: 1778594049826
 - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
   noarch: generic
   sha256: c31ab719d256bc6f89926131e88ecd0f0c5d003fe8481852c6424f4ec6c7eb29
@@ -3202,6 +3516,17 @@ packages:
   - pkg:pypi/backports-zstd?source=hash-mapping
   size: 241051
   timestamp: 1767045000787
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.5.0-py312h87c4bb7_0.conda
+  sha256: a492dcf07b1c58797b3192f11aef7e3beb18ec91646d6a5acfe5c6e61e66118d
+  md5: 6ec306e02579965dc9c01092a5f4ce4c
+  depends:
+  - python
+  - __osx >=11.0
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  size: 240840
+  timestamp: 1778594074672
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-5.0.0-py311h902ca64_1.conda
   sha256: 978ce415ca2868f8415ce54a9c33fe2d2c9efd6a78dc1a6fe79a4bc3d055fe66
   md5: 28b014780cae10a8435d012ef08c0202
@@ -3403,6 +3728,18 @@ packages:
   - pkg:pypi/boto3?source=compressed-mapping
   size: 85298
   timestamp: 1773730312937
+- conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.6-pyhd8ed1ab_0.conda
+  sha256: 27f1ca25bfc61de474f0aeef4feb7e34e01269b2eb06412a9320791533383692
+  md5: a4d90047a40699a07e946715b1ac8f56
+  depends:
+  - botocore >=1.43.6,<1.44.0
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10
+  - s3transfer >=0.17.0,<0.18.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 85858
+  timestamp: 1778482071121
 - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.42.69-pyhd8ed1ab_0.conda
   sha256: 24de926a5c762c5725f650ad213e711f6d8087cb45f3c5294a3f6d64b32cfd43
   md5: 912c27fe2ec99c4000a5eea1511c6ce1
@@ -3417,6 +3754,18 @@ packages:
   - pkg:pypi/botocore?source=hash-mapping
   size: 8334966
   timestamp: 1773710352786
+- conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.6-pyhd8ed1ab_0.conda
+  sha256: ed311e905e82fd427a23e9e2beccf2af483aa275529954c067a182730ceedde8
+  md5: 4ecc7dd446c60b1814a4ecb0a6b8f4bb
+  depends:
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10
+  - python-dateutil >=2.1,<3.0.0
+  - urllib3 >=1.25.4,!=2.2.0,<3
+  license: Apache-2.0
+  license_family: Apache
+  size: 8602564
+  timestamp: 1778463777684
 - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py311h66f275b_1.conda
   sha256: c36eb061d9ead85f97644cfb740d485dba9b8823357f35c17851078e95e975c1
   md5: 86daecb8e4ed1042d5dc6efbe0152590
@@ -3564,6 +3913,14 @@ packages:
   purls: []
   size: 147413
   timestamp: 1772006283803
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+  sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
+  md5: e18ad67cf881dcadee8b8d9e2f8e5f73
+  depends:
+  - __unix
+  license: ISC
+  size: 131039
+  timestamp: 1776865545798
 - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
   noarch: python
   sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
@@ -3675,6 +4032,14 @@ packages:
   - pkg:pypi/certifi?source=compressed-mapping
   size: 151445
   timestamp: 1772001170301
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
+  sha256: 989db6e5957c4b44fa600c68c681ec2f36a55e48f7c7f1c073d5e91caa8cd878
+  md5: 929471569c93acefb30282a22060dcd5
+  depends:
+  - python >=3.10
+  license: ISC
+  size: 135656
+  timestamp: 1776866680878
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py311h03d9500_1.conda
   sha256: 3ad13377356c86d3a945ae30e9b8c8734300925ef81a3cb0a9db0d755afbe7bb
   md5: 3912e4373de46adafd8f1e97e4bd166b
@@ -3761,6 +4126,15 @@ packages:
   - pkg:pypi/charset-normalizer?source=compressed-mapping
   size: 58510
   timestamp: 1773660086450
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+  sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
+  md5: a9167b9571f3baa9d448faa2139d1089
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 58872
+  timestamp: 1775127203018
 - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
   name: click
   version: 8.3.1
@@ -3781,6 +4155,17 @@ packages:
   - pkg:pypi/click?source=hash-mapping
   size: 97676
   timestamp: 1764518652276
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
+  sha256: 37a5d8b10ea3516e2c42f870c9c351b9f7b31ff48c66d83490039f417e1e5228
+  md5: 2266262ce8a425ecb6523d765f79b303
+  depends:
+  - __unix
+  - python
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100048
+  timestamp: 1777219902525
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-didyoumean-0.3.1-pyhd8ed1ab_1.conda
   sha256: f3e6540088db593707766aa30abe184463e4842182012ffb81e1cc784dbdc436
   md5: dd87c399586cac9f8bdd8c644b2592a6
@@ -4050,6 +4435,22 @@ packages:
   license_family: BSD
   size: 1913519
   timestamp: 1777966158377
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-48.0.0-py312ha4b625e_0.conda
+  sha256: 16d3d1e8df34a36430a28f423380fbd93abe5670ca7b52e9f4a64c091fd3ddd9
+  md5: c5a8e173200adf567dc2818d8bf1325f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=2.0
+  - libgcc >=14
+  - openssl >=3.5.6,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1912222
+  timestamp: 1777966300032
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.5-py311hfdedaa2_0.conda
   sha256: 2a261ae8c02a41a225536bdcc6f0fa2c9452fc78ca0b49bed954fab2a7cf0190
   md5: 4a85ff1f8470859270b03f6b655a4e14
@@ -4083,6 +4484,21 @@ packages:
   license_family: BSD
   size: 1855763
   timestamp: 1777966249758
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-48.0.0-py312h1238841_0.conda
+  sha256: f2560a639d9f67c53f495d75289a63b840744be04669dc949afb0e694f971fdb
+  md5: 7a4c2757d53e6a36c45f0eeaf50dac34
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.6,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1853060
+  timestamp: 1777966201485
 - pypi: https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: cuda-bindings
   version: 12.9.4
@@ -4919,6 +5335,19 @@ packages:
   license_family: APACHE
   size: 55258
   timestamp: 1752167340913
+- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
+  sha256: f4e0e6cd241bc24afb2d6d08e5d2ba170fad2475e522bdf297b7271bba268be6
+  md5: 63e20cf7b7460019b423fc06abb96c60
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  size: 55037
+  timestamp: 1752167383781
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py311h8740443_0.conda
   sha256: b0b21e436d52d15cd29996ddbaa9eff04151b57330e35f436aab6ba303601ae8
   md5: e15cfa88d7671c12a25a574b63f63d9d
@@ -4932,6 +5361,19 @@ packages:
   license_family: APACHE
   size: 51115
   timestamp: 1752167450180
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
+  sha256: 690af95d69d97b6e1ffead1edd413ca0f8b9189fb867b6bd8fd351f8ad509043
+  md5: 9f016ae66f8ef7195561dbf7ce0e5944
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  size: 52265
+  timestamp: 1752167495152
 - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
   name: fsspec
   version: 2026.2.0
@@ -5040,6 +5482,15 @@ packages:
   - zstandard ; python_full_version < '3.14' and extra == 'test-full'
   - tqdm ; extra == 'tqdm'
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
+  sha256: 079701b4ff3b317a1a158cabd48cf2b856b8b8d3ef44f152809d9acf20cc8e10
+  md5: 2c11aa96ea85ced419de710c1c3a78ff
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 149694
+  timestamp: 1777547807038
 - pypi: https://files.pythonhosted.org/packages/c4/98/66a06b82a5c840f896490d5ef9c7691776b147589f2e8d2fa66c67a3db9c/genai_prices-0.0.55-py3-none-any.whl
   name: genai-prices
   version: 0.0.55
@@ -5728,6 +6179,17 @@ packages:
   purls: []
   size: 12728445
   timestamp: 1767969922681
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+  sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+  md5: c80d8a3b84358cb967fa81e7075fbc8a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 12723451
+  timestamp: 1773822285671
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-hef89b57_0.conda
   sha256: 24bc62335106c30fecbcc1dba62c5eba06d18b90ea1061abd111af7b9c89c2d7
   md5: 114e6bfe7c5ad2525eb3597acdbf2300
@@ -5738,6 +6200,15 @@ packages:
   purls: []
   size: 12389400
   timestamp: 1772209104304
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+  sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
+  md5: f1182c91c0de31a7abd40cedf6a5ebef
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 12361647
+  timestamp: 1773822915649
 - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.17-pyhd8ed1ab_0.conda
   sha256: 7cd5eccdb171a0adbf83a1ad8fc4e17822f4fc3f5518da9040de64e88bc07343
   md5: 5b7ae2ec4e0750e094f804a6cf1b2a37
@@ -5761,6 +6232,16 @@ packages:
   - pkg:pypi/idna?source=hash-mapping
   size: 50721
   timestamp: 1760286526795
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.13-pyhcf101f3_0.conda
+  sha256: 9ab620e6f64bb67737bd7bc1ad6f480770124e304c6710617aba7fe60b089f48
+  md5: fb7130c190f9b4ec91219840a05ba3ac
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59038
+  timestamp: 1776947141407
 - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
   name: imageio
   version: 2.37.3
@@ -5836,6 +6317,17 @@ packages:
   - pkg:pypi/importlib-metadata?source=hash-mapping
   size: 34641
   timestamp: 1747934053147
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+  sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
+  md5: 080594bf4493e6bae2607e65390c520a
+  depends:
+  - python >=3.10
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 34387
+  timestamp: 1773931568510
 - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
   name: iniconfig
   version: 2.3.0
@@ -6703,6 +7195,18 @@ packages:
   purls: []
   size: 725507
   timestamp: 1770267139900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
+  md5: 18335a698559cdbcd86150a48bf54ba6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.45.1
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 728002
+  timestamp: 1774197446916
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
   sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   md5: a752488c68f2e7c456bcbd8f16eec275
@@ -7208,6 +7712,15 @@ packages:
   purls: []
   size: 570281
   timestamp: 1773203613980
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.5-h55c6f16_1.conda
+  sha256: dddd01bd6b338221342a89530a1caffe6051a70cc8f8b1d8bb591d5447a3c603
+  md5: ff484b683fecf1e875dfc7aa01d19796
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 569359
+  timestamp: 1778191546305
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
   sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
   md5: 6c77a605a7a689d17d4819c0f8ac9a00
@@ -7302,6 +7815,18 @@ packages:
   purls: []
   size: 76798
   timestamp: 1771259418166
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
+  sha256: ea33c40977ea7a2c3658c522230058395bc2ee0d89d99f0711390b6a1ee80d12
+  md5: a3b390520c563d78cc58974de95a03e5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.0.*
+  license: MIT
+  license_family: MIT
+  size: 77241
+  timestamp: 1777846112704
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
   sha256: 03887d8080d6a8fe02d75b80929271b39697ecca7628f0657d7afaea87761edf
   md5: a92e310ae8dfc206ff449f362fc4217f
@@ -7314,6 +7839,17 @@ packages:
   purls: []
   size: 68199
   timestamp: 1771260020767
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.0-hf6b4638_0.conda
+  sha256: f4b1cafc59afaede8fa0a2d9cf376840f1c553001acd72f6ead18bbc8ac8c49c
+  md5: 65466e82c09e888ca7560c11a97d5450
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.8.0.*
+  license: MIT
+  license_family: MIT
+  size: 68789
+  timestamp: 1777846180142
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -7344,6 +7880,14 @@ packages:
   purls: []
   size: 8035
   timestamp: 1772757210108
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+  sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
+  md5: e289f3d17880e44b633ba911d57a321b
+  depends:
+  - libfreetype6 >=2.14.3
+  license: GPL-2.0-only OR FTL
+  size: 8049
+  timestamp: 1774298163029
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.2-hce30654_0.conda
   sha256: 6061ef5321b8e697d5577d8dfe7a4c75bfe3e706c956d0d84bfec6bea3ed9f77
   md5: a3a53232936b55ffea76806aefe19e8b
@@ -7353,6 +7897,14 @@ packages:
   purls: []
   size: 8076
   timestamp: 1772756349852
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_0.conda
+  sha256: a047a2f238362a37d484f9620e8cba29f513a933cd9eb68571ad4b270d6f8f3e
+  md5: f73b109d49568d5d1dda43bb147ae37f
+  depends:
+  - libfreetype6 >=2.14.3
+  license: GPL-2.0-only OR FTL
+  size: 8091
+  timestamp: 1774298691258
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.2-h73754d4_0.conda
   sha256: aba65b94bdbed52de17ec3d0c6f2ebac2ef77071ad22d6900d1614d0dd702a0c
   md5: 8eaba3d1a4d7525c6814e861614457fd
@@ -7367,6 +7919,19 @@ packages:
   purls: []
   size: 386316
   timestamp: 1772757193822
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+  sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
+  md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.55,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - freetype >=2.14.3
+  license: GPL-2.0-only OR FTL
+  size: 384575
+  timestamp: 1774298162622
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.2-hdfa99f5_0.conda
   sha256: 24dd0e0bee56e87935f885929f67659f1d3b8a01e7546568de2919cffd9e2e36
   md5: e726e134a392ae5d7bafa6cc4a3d5725
@@ -7380,6 +7945,18 @@ packages:
   purls: []
   size: 338032
   timestamp: 1772756347899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_0.conda
+  sha256: ff764608e1f2839e95e2cf9b243681475f8778c36af7a42b3f78f476fdbb1dd3
+  md5: e98ba7b5f09a5f450eca083d5a1c4649
+  depends:
+  - __osx >=11.0
+  - libpng >=1.6.55,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - freetype >=2.14.3
+  license: GPL-2.0-only OR FTL
+  size: 338085
+  timestamp: 1774298689297
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
   sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
   md5: 0aa00f03f9e39fb9876085dee11a85d4
@@ -7394,6 +7971,19 @@ packages:
   purls: []
   size: 1041788
   timestamp: 1771378212382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+  md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_19
+  - libgomp 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1041084
+  timestamp: 1778269013026
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_18.conda
   sha256: 1d9c4f35586adb71bcd23e31b68b7f3e4c4ab89914c26bed5f2859290be5560e
   md5: 92df6107310b1fff92c4cc84f0de247b
@@ -7417,6 +8007,15 @@ packages:
   purls: []
   size: 27526
   timestamp: 1771378224552
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
+  md5: 331ee9b72b9dff570d56b1302c5ab37d
+  depends:
+  - libgcc 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 27694
+  timestamp: 1778269016987
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.12.1-hb03c661_0.conda
   sha256: 7be98990d9659a3b152dd7d6dc4eb57a7d47d7267bf7067b6ab78c022e3da38f
   md5: 2c4c159d916a552237fe361cf383eeb5
@@ -7525,6 +8124,21 @@ packages:
   license: LGPL-2.1-or-later
   size: 4398701
   timestamp: 1771863239578
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+  sha256: 33eb5d5310a5c2c0a4707a0afa644801c2e08c8f70c45e1f62f354116dfe0970
+  md5: 17d484ab9c8179c6a6e5b7dbb5065afc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libffi >=3.5.2,<3.6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  constrains:
+  - glib >2.66
+  license: LGPL-2.1-or-later
+  size: 4754097
+  timestamp: 1778508800134
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.86.4-he378b5c_1.conda
   sha256: a4254a241a96198e019ced2e0d2967e4c0ef64fac32077a45c065b32dc2b15d2
   md5: 673069f6725ed7b1073f9b96094294d1
@@ -7540,6 +8154,21 @@ packages:
   license: LGPL-2.1-or-later
   size: 4108927
   timestamp: 1771864169970
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
+  sha256: 3b32a7a710132d509f2ea38b2f0384414c863533e0fc7ac71b6a0763e4c67424
+  md5: 62d6f3b832d7d79ae0c0aa1bb3c325fa
+  depends:
+  - __osx >=11.0
+  - libintl >=0.25.1,<1.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - glib >2.66
+  license: LGPL-2.1-or-later
+  size: 4439458
+  timestamp: 1778508895255
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
   sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
   md5: 239c5e9546c38a1e884d69effcf4c882
@@ -7550,6 +8179,15 @@ packages:
   purls: []
   size: 603262
   timestamp: 1771378117851
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  md5: faac990cb7aedc7f3a2224f2c9b0c26c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 603817
+  timestamp: 1778268942614
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.43.0-h9d11ab5_0.conda
   sha256: 3af9545922cfd846a5f5dd7084a1e595a2d970890b67a1ea8db6eefafd3f083e
   md5: f728a0df6f939f4e87d82f4dcf114290
@@ -7630,6 +8268,16 @@ packages:
   license: LGPL-2.1-only
   size: 319774
   timestamp: 1777108822091
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.61-h54a6638_0.conda
+  sha256: 22c789e7186380e0c728d6ab4064e5b026aab112a10ecb8b7a6eb270adfcd7d8
+  md5: f980b2ea1d227356414a2fb47be406de
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  license: LGPL-2.1-only
+  size: 318054
+  timestamp: 1778157441447
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgpg-error-1.60-h784d473_0.conda
   sha256: 6461bf936b829d4a67f4257bc35d7dc0831d570966c511935e8f2ad792472614
   md5: 8fa5962cc43a6522e263bcdb2a6eb385
@@ -7640,6 +8288,16 @@ packages:
   license: LGPL-2.1-only
   size: 303940
   timestamp: 1777108909506
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgpg-error-1.61-h784d473_0.conda
+  sha256: 2afc962e00e22308bf56c82adfef9568a75a673eee451d35951e06ac16ac2460
+  md5: 26ebbe9d6dd0267388ce901fb74b92bd
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - libintl >=0.25.1,<1.0a0
+  license: LGPL-2.1-only
+  size: 301691
+  timestamp: 1778157480078
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.0-h1d1128b_1.conda
   sha256: f6861217d6c4bf96283738ba8d55782fccb577513a6cd346abc60cf88d1795df
   md5: 66055700c90b50c0405a4e515bb4fe3c
@@ -7806,6 +8464,17 @@ packages:
   purls: []
   size: 113207
   timestamp: 1768752626120
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+  md5: b88d90cad08e6bc8ad540cb310a761fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  size: 113478
+  timestamp: 1775825492909
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
   sha256: 7bfc7ffb2d6a9629357a70d4eadeadb6f88fa26ebc28f606b1c1e5e5ed99dc7e
   md5: 009f0d956d7bfb00de86901d16e486c7
@@ -7817,6 +8486,16 @@ packages:
   purls: []
   size: 92242
   timestamp: 1768752982486
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
+  md5: b1fd823b5ae54fbec272cea0811bd8a9
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  size: 92472
+  timestamp: 1775825802659
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
   sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
   md5: 2c21e66f50753a083cbe6b80f38268fa
@@ -8030,6 +8709,16 @@ packages:
   purls: []
   size: 317669
   timestamp: 1770691470744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+  sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+  md5: eba48a68a1a2b9d3c0d9511548db85db
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: zlib-acknowledgement
+  size: 317729
+  timestamp: 1776315175087
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.55-h132b30e_0.conda
   sha256: 7a4fd29a6ee2d7f7a6e610754dfdf7410ed08f40d8d8b488a27bc0f9981d5abb
   md5: 871dc88b0192ac49b6a5509932c31377
@@ -8040,6 +8729,15 @@ packages:
   purls: []
   size: 288950
   timestamp: 1770691485950
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
+  sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
+  md5: 2259ae0949dbe20c0665850365109b27
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  license: zlib-acknowledgement
+  size: 289546
+  timestamp: 1776315246750
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
   sha256: afbf195443269ae10a940372c1d37cda749355d2bd96ef9587a962abd87f2429
   md5: 11ac478fa72cf12c214199b8a96523f4
@@ -8153,6 +8851,16 @@ packages:
   purls: []
   size: 951405
   timestamp: 1772818874251
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+  sha256: 54cdcd3214313b62c2a8ee277e6f42150d9b748264c1b70d958bf735e420ef8d
+  md5: 7dc38adcbf71e6b38748e919e16e0dce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 954962
+  timestamp: 1777986471789
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
   sha256: beb0fd5594d6d7c7cd42c992b6bb4d66cbb39d6c94a8234f15956da99a04306c
   md5: f6233a3fddc35a2ec9f617f79d6f3d71
@@ -8164,6 +8872,15 @@ packages:
   purls: []
   size: 918420
   timestamp: 1772819478684
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
+  sha256: 49daec7c83e70d4efc17b813547824bc2bcf2f7256d84061d24fbfe537da9f74
+  md5: 6681822ea9d362953206352371b6a904
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 920047
+  timestamp: 1777987051643
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -8199,6 +8916,18 @@ packages:
   purls: []
   size: 5852330
   timestamp: 1771378262446
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+  md5: 5794b3bdc38177caf969dabd3af08549
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_19
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 5852044
+  timestamp: 1778269036376
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
   sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
   md5: 6235adb93d064ecdf3d44faee6f468de
@@ -8301,6 +9030,16 @@ packages:
   purls: []
   size: 40311
   timestamp: 1766271528534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+  sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
+  md5: 38ffe67b78c9d4de527be8315e5ada2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40297
+  timestamp: 1775052476770
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
   sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
   md5: 0f03292cc56bf91a077a134ea8747118
@@ -8454,6 +9193,17 @@ packages:
   purls: []
   size: 60963
   timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 63629
+  timestamp: 1774072609062
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
   sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
   md5: 369964e85dc26bfe78f41399b366c435
@@ -8466,6 +9216,17 @@ packages:
   purls: []
   size: 46438
   timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+  md5: bc5a5721b6439f2f62a84f2548136082
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 47759
+  timestamp: 1774072956767
 - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.1.0-pyhcf101f3_0.conda
   sha256: 991a82fbb64aba6d10719a017ce354e28df02ea5df1d9c7b0221da573c168d27
   md5: 1005e1f39083adad2384772e8e384e43
@@ -9241,6 +10002,20 @@ packages:
   license_family: MIT
   size: 40544
   timestamp: 1758663858058
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msal_extensions-1.3.1-py312h7900ff3_1.conda
+  sha256: e2475aab5cf20b44700431c4e44ecfd4961bb19a67a7f016b00c7fa051832ebf
+  md5: 488750be5833a340ff2a8215883d7e4c
+  depends:
+  - libsecret
+  - msal >=1.29,<2
+  - portalocker >=1.6,<4
+  - pygobject >=3,<4
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  size: 39386
+  timestamp: 1758663859368
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msal_extensions-1.3.1-py311h267d04e_1.conda
   sha256: 4316d53da5094b496e89367202a140308aeef9c54da678bd80b0870bf7869d7c
   md5: 90f7479aa6e3878a5e5348ead0a0c3b4
@@ -9256,6 +10031,21 @@ packages:
   license_family: MIT
   size: 41184
   timestamp: 1758664038500
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msal_extensions-1.3.1-py312h81bd7bf_1.conda
+  sha256: 250e912eb918df53f0b7548c1f9b692e6e811646f1fc4506ed460b8d536308a7
+  md5: d54fa30de269e01d8845a69f075b62c8
+  depends:
+  - libsecret
+  - msal >=1.29,<2
+  - portalocker >=1.6,<4
+  - pygobject >=3,<4
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  size: 40238
+  timestamp: 1758664083637
 - conda: https://conda.anaconda.org/conda-forge/linux-64/msgspec-0.20.0-py311h49ec1c0_2.conda
   sha256: 1f5599c2f9bfd4ca8d11fe0d2226c65a20fda84067563cd8ae29874d48594058
   md5: f4196f0cf8ae9ca2141980c1637f2f2a
@@ -9326,6 +10116,18 @@ packages:
   - pkg:pypi/multidict?source=hash-mapping
   size: 100649
   timestamp: 1771610839808
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
+  sha256: 0da7e7f4e69bfd6c98eff92523e93a0eceeaec1c6d503d4a4cd0af816c3fe3dc
+  md5: 17c77acc59407701b54404cfd3639cac
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  size: 100056
+  timestamp: 1771611023053
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py311ha275503_0.conda
   sha256: 01aae5d525f7eec07bfe9d9cd82cae84d5889babdfe4bd3b674b734005289cfe
   md5: a57b7e57a380097482d5a89a44f0a5c4
@@ -9340,6 +10142,18 @@ packages:
   - pkg:pypi/multidict?source=compressed-mapping
   size: 89354
   timestamp: 1771611632254
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py312h43af8aa_0.conda
+  sha256: d7f2c4137271b158a452d02a5a3c4ceade8e8e75352fc90a4360f4a7eda9be9f
+  md5: 8094abe00f22955a9396d91c690f36e8
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  size: 87852
+  timestamp: 1771611147963
 - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
   name: mypy-extensions
   version: 1.1.0
@@ -9447,6 +10261,15 @@ packages:
   purls: []
   size: 891641
   timestamp: 1738195959188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+  md5: fc21868a1a5aacc937e7a18747acb8a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  size: 918956
+  timestamp: 1777422145199
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
   sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
   md5: 068d497125e4bf8a66bf707254fff5ae
@@ -9456,6 +10279,14 @@ packages:
   purls: []
   size: 797030
   timestamp: 1738196177597
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
+  md5: 343d10ed5b44030a2f67193905aea159
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 805509
+  timestamp: 1777423252320
 - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
   sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
   md5: 598fd7d4d0de2455fb74f56063969a97
@@ -9896,6 +10727,17 @@ packages:
   purls: []
   size: 3164551
   timestamp: 1769555830639
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
+  md5: da1b85b6a87e141f5140bb9924cecab0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 3167099
+  timestamp: 1775587756857
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
   sha256: 361f5c5e60052abc12bdd1b50d7a1a43e6a6653aab99a2263bf2288d709dcf67
   md5: f4f6ad63f98f64191c3e77c5f5f29d76
@@ -9907,6 +10749,16 @@ packages:
   purls: []
   size: 3104268
   timestamp: 1769556384749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+  sha256: c91bf510c130a1ea1b6ff023e28bac0ccaef869446acd805e2016f69ebdc49ea
+  md5: 25dcccd4f80f1638428613e0d7c9b4e1
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 3106008
+  timestamp: 1775587972483
 - pypi: https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl
   name: opentelemetry-api
   version: 1.40.0
@@ -10078,6 +10930,16 @@ packages:
   - pkg:pypi/packaging?source=compressed-mapping
   size: 72010
   timestamp: 1769093650580
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
+  md5: 4c06a92e74452cfa53623a81592e8934
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 91574
+  timestamp: 1777103621679
 - pypi: https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl
   name: pandas
   version: 2.3.3
@@ -10840,6 +11702,16 @@ packages:
   license_family: PSF
   size: 57250
   timestamp: 1757395771493
+- conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-3.2.0-py312h7900ff3_1.conda
+  sha256: f0cb3cfcc51394f5b52ec92e8fe27f8fff02853fe2e66c3ae111d7149e440115
+  md5: 21a906c6a6f29bb1cb968a7711f6f894
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: PSF-2.0
+  license_family: PSF
+  size: 56441
+  timestamp: 1757395777358
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portalocker-3.2.0-py311h267d04e_1.conda
   sha256: 09475336f5e150ae718b3266811c7cd7ec932238f4c689d29c8314f1b3bb4683
   md5: fdeeb5fa4a6234e5f6bdd9a825a63745
@@ -10851,6 +11723,17 @@ packages:
   license_family: PSF
   size: 57686
   timestamp: 1757395960265
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/portalocker-3.2.0-py312h81bd7bf_1.conda
+  sha256: 9e9eefb4775b169fa22f96edcd8f5059f682d288c5971266163a5ea2718aaacc
+  md5: 505081291f86f371172d75a2672a1804
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: PSF-2.0
+  license_family: PSF
+  size: 56879
+  timestamp: 1757395908630
 - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
   sha256: c2b964c86b2cd00e494093d751b1f8697b3c4bf924ff70648387af161444cc82
   md5: 004cff3a7f6fafb0a041fb575de85185
@@ -10973,6 +11856,18 @@ packages:
   - pkg:pypi/propcache?source=hash-mapping
   size: 54558
   timestamp: 1744525097548
+- conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
+  sha256: d0ff67d89cf379a9f0367f563320621f0bc3969fe7f5c85e020f437de0927bb4
+  md5: 0cf580c1b73146bb9ff1bbdb4d4c8cf9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54233
+  timestamp: 1744525107433
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py311h4921393_0.conda
   sha256: 559f330cc40372422f8d9d5068b905b80d6762a8c2c7aeb4886a98ed7023c686
   md5: 667f23d757cbfa63e8b3ecc7e7d34b18
@@ -10987,6 +11882,18 @@ packages:
   - pkg:pypi/propcache?source=hash-mapping
   size: 51291
   timestamp: 1744525140418
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
+  sha256: dd97df075f5198d42cc4be6773f1c41a9c07d631d95f91bfee8e9953eccc965b
+  md5: d8280c97e09e85c72916a3d98a4076d7
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51972
+  timestamp: 1744525285336
 - pypi: https://files.pythonhosted.org/packages/06/db/49b05966fd208ae3f44dcd33837b6243b4915c57561d730a43f881f24dea/protobuf-5.29.6-cp38-abi3-macosx_10_9_universal2.whl
   name: protobuf
   version: 5.29.6
@@ -11364,6 +12271,20 @@ packages:
   license: LGPL-2.1-only OR MPL-1.1
   size: 120125
   timestamp: 1770726341517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py312h2596900_1.conda
+  sha256: 15b5392d2755b771cb6830ae0377ed71bf2bcfd33a347dbc3195df80568ce42c
+  md5: 7766c2ad93e65415f4289de684261550
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-2.1-only OR MPL-1.1
+  size: 119839
+  timestamp: 1770726341594
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycairo-1.29.0-py311ha1fe154_1.conda
   sha256: 569073f1828fbae0445e5376f92a13198bf7acfaa7e6ee1da4c9207619ef0c7f
   md5: e1f64afd5d0d0f6b342c1366149a1eca
@@ -11378,6 +12299,20 @@ packages:
   license: LGPL-2.1-only OR MPL-1.1
   size: 106031
   timestamp: 1770727193495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycairo-1.29.0-py312h2437029_0.conda
+  sha256: 343bdde9b0d80caed910fc6a071d86b81c7c7240be1d5fdbfa7eb9153c55136d
+  md5: 7a27a42db2d7cc92779abbc26e24d343
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.4,<2.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: LGPL-2.1-only OR MPL-1.1
+  size: 105984
+  timestamp: 1763047065752
 - pypi: https://files.pythonhosted.org/packages/7a/06/6e3e241882bf7d6ab23d9c69ba4e85f1ec47397cbbeee948a16cf75e21ed/pyclipper-1.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: pyclipper
   version: 1.4.0
@@ -11640,6 +12575,28 @@ packages:
   license_family: LGPL
   size: 448398
   timestamp: 1770818443290
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pygobject-3.56.3-py312h4785a91_0.conda
+  sha256: e7627633a003117db2acfab8d8151ef0cb163216023e707df7f5714b5d81912b
+  md5: c83a6569c35fce82e0cdcd3d15f776b6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - libexpat >=2.8.0,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libgirepository
+  - libglib >=2.88.1,<3.0a0
+  - libiconv
+  - libzlib >=1.3.2,<2.0a0
+  - pycairo
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 413589
+  timestamp: 1778343379983
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pygobject-3.54.5-py311hb0c0c64_3.conda
   sha256: c2325711dac2e6895092ef41ebcd5fa441134e96988c8acb9dd53bcbec580124
   md5: 53c33e0c8653363eb165645e5f02b7b7
@@ -11660,6 +12617,28 @@ packages:
   license_family: LGPL
   size: 323938
   timestamp: 1770819096914
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pygobject-3.56.3-py312h189c030_0.conda
+  sha256: 061f99f622da355f3350a9f2871eddfdd5064f70d65d9b8fca959135aaac87e0
+  md5: 0a1bfc2602701b44758ac25b706842a6
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.4,<2.0a0
+  - libexpat >=2.8.0,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgirepository
+  - libglib >=2.88.1,<3.0a0
+  - libiconv
+  - libzlib >=1.3.2,<2.0a0
+  - pycairo
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 314061
+  timestamp: 1778343804207
 - pypi: https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl
   name: pyjwt
   version: 2.12.1
@@ -12112,6 +13091,15 @@ packages:
   - pkg:pypi/tzdata?source=hash-mapping
   size: 143542
   timestamp: 1765719982349
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
+  sha256: e943f9c15a6bdba2e1b9f423ab913b3f6b02197b0ef9f8e6b7464d78b59965b9
+  md5: f6ad7450fc21e00ecc23812baed6d2e4
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: APACHE
+  size: 146639
+  timestamp: 1777068997932
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
   build_number: 8
   sha256: fddf123692aa4b1fc48f0471e346400d9852d96eeed77dbfdd746fa50a8ff894
@@ -12433,6 +13421,22 @@ packages:
   - pkg:pypi/requests?source=compressed-mapping
   size: 63602
   timestamp: 1766926974520
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.0-pyhcf101f3_0.conda
+  sha256: 4487fdb341537e2df47159ed8e546add99080974c52d5b2dc2a710910619115a
+  md5: a5985537dab1ba7034b5ff4ea22e2fa9
+  depends:
+  - python >=3.10
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - urllib3 >=1.26,<3
+  - python
+  constrains:
+  - chardet >=3.0.2,<8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 68658
+  timestamp: 1778534036810
 - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
   name: requests-toolbelt
   version: 1.0.0
@@ -12617,6 +13621,16 @@ packages:
   - pkg:pypi/s3transfer?source=hash-mapping
   size: 66717
   timestamp: 1764589830083
+- conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.17.0-pyhd8ed1ab_0.conda
+  sha256: 848ed74bfe68c2f45f6de54186480df7c079b791b60db3b948d4eb7963f8621e
+  md5: 6f92735891911568fd92b40e0bb2d04e
+  depends:
+  - botocore >=1.37.4,<2.0a.0
+  - python >=3.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 67379
+  timestamp: 1777547821065
 - pypi: https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: safetensors
   version: 0.7.0
@@ -14991,6 +16005,19 @@ packages:
   - pkg:pypi/urllib3?source=hash-mapping
   size: 103172
   timestamp: 1767817860341
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+  md5: cbb88288f74dbe6ada1c6c7d0a97223e
+  depends:
+  - backports.zstd >=1.0.0
+  - brotli-python >=1.2.0
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 103560
+  timestamp: 1778188657149
 - pypi: https://files.pythonhosted.org/packages/43/b7/add4363039a34506a58457d96d4aa2126061df3a143eb4d042aedd6a2e76/uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
   name: uuid-utils
   version: 0.14.1
@@ -15171,6 +16198,15 @@ packages:
   - pkg:pypi/wcwidth?source=hash-mapping
   size: 71550
   timestamp: 1770634638503
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
+  sha256: 1ee2d8384972ecbf8630ce8a3ea9d16858358ad3e8566675295e66996d5352da
+  md5: eb9538b8e55069434a18547f43b96059
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 82917
+  timestamp: 1777744489106
 - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
   sha256: 21f6c8a20fe050d09bfda3fb0a9c3493936ce7d6e1b3b5f8b01319ee46d6c6f6
   md5: 6639b6b0d8b5a284f027a2003669aa65
@@ -15251,6 +16287,17 @@ packages:
   - pkg:pypi/werkzeug?source=hash-mapping
   size: 257130
   timestamp: 1771530143814
+- conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
+  sha256: 5108c1bf2f0512e5c9dc8191e31b144c23b7cf0e73423a246173006002368d79
+  md5: 3eeca039e7316268627f4116da9df64c
+  depends:
+  - markupsafe >=2.1.1
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 258232
+  timestamp: 1775160081069
 - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
   sha256: d6cf2f0ebd5e09120c28ecba450556ce553752652d91795442f0e70f837126ae
   md5: bdbd7385b4a67025ac2dba4ef8cb6a8f
@@ -15524,6 +16571,21 @@ packages:
   - pkg:pypi/yarl?source=compressed-mapping
   size: 149070
   timestamp: 1772409506948
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.23.0-py312h8a5da7c_0.conda
+  sha256: 5d991a8f418675338528ea8097e55143ad833807a110c4251879040351e0d4af
+  md5: 4b403cb52e72211c489a884b29290c2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - idna >=2.0
+  - libgcc >=14
+  - multidict >=4.0
+  - propcache >=0.2.1
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  size: 147028
+  timestamp: 1772409590700
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.23.0-py311hc290fe0_0.conda
   sha256: ff782e7bcc57a4387989b14ddfb6142e0b6890cec187cc05c1c9da693d171fd0
   md5: e4d202b8b445cb3e3fd60f3f48881a11
@@ -15541,6 +16603,21 @@ packages:
   - pkg:pypi/yarl?source=compressed-mapping
   size: 142272
   timestamp: 1772409712668
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.23.0-py312h04c11ed_0.conda
+  sha256: 2379fd978cfc5598d9ef6f01946da890851f5ed22ecf8596abb328f7ddd640ba
+  md5: c5cce9282c0a099ba55a43a80fc67795
+  depends:
+  - __osx >=11.0
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.1
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  size: 140208
+  timestamp: 1772409657987
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
   sha256: 325d370b28e2b9cc1f765c5b4cdb394c91a5d958fbd15da1a14607a28fee09f6
   md5: 755b096086851e1193f3b10347415d7c
@@ -15580,6 +16657,16 @@ packages:
   - pkg:pypi/zipp?source=hash-mapping
   size: 24194
   timestamp: 1764460141901
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
+  sha256: 523616c0530d305d2216c2b4a8dfd3872628b60083255b89c5e0d8c42e738cca
+  md5: e1c36c6121a7c9c76f2f148f1e83b983
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 24461
+  timestamp: 1776131454755
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
   sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
   md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8

--- a/pixi.toml
+++ b/pixi.toml
@@ -80,7 +80,12 @@ streamlit = "*"
 tenacity = "==8.5.0"
 
 [environments]
-llmaven = { features = ["docker", "llmaven", "pulumi", "pre-commit"], no-default-feature = true }
+llmaven = { features = [
+    "docker",
+    "llmaven",
+    "pulumi",
+    "pre-commit",
+], no-default-feature = true }
 frontend = { features = ["frontend"], no-default-feature = true }
 infra = { features = [
     "infra",
@@ -88,11 +93,18 @@ infra = { features = [
 proxy = { features = [
     "proxy",
 ], solve-group = "proxy", no-default-feature = true }
+backup = { features = [
+    "backup",
+], solve-group = "backup", no-default-feature = true }
 
 # === LLMaven API dependencies and tasks ===
 
 [feature.llmaven.pypi-dependencies]
-llmaven = { path = ".", editable = true, extras = ["test", "deploy", "production"]}
+llmaven = { path = ".", editable = true, extras = [
+    "test",
+    "deploy",
+    "production",
+] }
 mlflow = "==3.10.0"
 jsonlines = ">=3.1.0,<4.0.0"
 
@@ -144,3 +156,14 @@ clean = { cmd = "docker-compose down -v", cwd = "docker" }
 
 [feature.pre-commit.dependencies]
 pre-commit = ">=3.4.0,<4"
+
+# === Backup dependencies and tasks ===
+
+[feature.backup.dependencies]
+python = "3.12.*"
+fsspec = ">=2024.0.0"
+adlfs = ">=2024.0.0"
+pyyaml = ">=6.0"
+
+[feature.backup.tasks]
+backup = { cmd = "python scripts/backup_postgres.py --config llmaven-backup-config.yaml", description = "Run PostgreSQL backup to cloud storage" }

--- a/scripts/backup_postgres.py
+++ b/scripts/backup_postgres.py
@@ -1,0 +1,140 @@
+"""Backup a PostgreSQL database to cloud storage (S3 or Azure Blob) via fsspec.
+
+Streams pg_dump stdout directly to the destination — no local disk writes.
+Destination URL controls the backend:
+  az://container/prefix/     → Azure Blob (adlfs)
+  s3://bucket/prefix/        → AWS S3 (s3fs)
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+import fsspec
+import yaml
+
+
+def _load_config(config_path: str) -> dict:
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def _parse_db_name(db_url: str) -> str:
+    name = urlparse(db_url).path.lstrip("/")
+    if not name:
+        raise ValueError(f"Could not parse database name from connection string")
+    return name
+
+
+def _storage_options(destination: str) -> dict:
+    """Build fsspec storage_options from env vars based on destination URL scheme."""
+    scheme = destination.split("://")[0]
+    if scheme in ("az", "abfs"):
+        # AZURE_STORAGE_CONNECTION_STRING takes priority — used for Azurite and
+        # other non-cloud endpoints where the endpoint URL differs from the default.
+        conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+        if conn_str:
+            return {"connection_string": conn_str}
+        opts = {}
+        account_name = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
+        account_key = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
+        if account_name:
+            opts["account_name"] = account_name
+        if account_key:
+            opts["account_key"] = account_key
+        return opts
+    # S3: boto3 picks up AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY automatically.
+    # AWS_ENDPOINT_URL overrides the endpoint — used for MinIO and other S3-compatible stores.
+    endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+    if endpoint_url:
+        return {"endpoint_url": endpoint_url}
+    return {}
+
+
+def backup(config_path: str | None = None) -> None:
+    if config_path:
+        config = _load_config(config_path)
+        pg_cfg = config["pg_backup"]
+        db_url_env = pg_cfg.get("database_url_env", "DATABASE_URL")
+        db_url = os.environ[db_url_env]
+        destination = pg_cfg["destination"].rstrip("/") + "/"
+        keep_last_n = int(pg_cfg.get("keep_last_n", 7))
+    else:
+        # Env-var mode — used by the Container Apps Job
+        db_url = os.environ["DATABASE_URL"]
+        destination = os.environ["BACKUP_DESTINATION"].rstrip("/") + "/"
+        keep_last_n = int(os.getenv("BACKUP_KEEP_LAST_N", "7"))
+
+    db_name = _parse_db_name(db_url)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    dest_key = f"{destination}{db_name}/{timestamp}.dump"
+
+    storage_opts = _storage_options(destination)
+
+    print(f"Backing up '{db_name}' → {dest_key}")
+
+    proc = subprocess.Popen(
+        ["pg_dump", "--format=custom", "--no-password", db_url],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        with fsspec.open(dest_key, "wb", **storage_opts) as f:
+            shutil.copyfileobj(proc.stdout, f)
+    finally:
+        proc.stdout.close()
+
+    stderr_out = proc.stderr.read()
+    proc.stderr.close()
+    proc.wait()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"pg_dump exited {proc.returncode}:\n{stderr_out.decode(errors='replace')}"
+        )
+
+    print(f"Upload complete.")
+
+    # Prune backups beyond keep_last_n
+    fs, root = fsspec.core.url_to_fs(destination, **storage_opts)
+    prefix = root.rstrip("/") + f"/{db_name}/"
+
+    try:
+        entries = sorted(fs.ls(prefix, detail=False))
+    except FileNotFoundError:
+        entries = []
+
+    if len(entries) > keep_last_n:
+        for old in entries[:-keep_last_n]:
+            fs.rm(old)
+            print(f"Deleted old backup: {old}")
+
+    retained = min(len(entries), keep_last_n)
+    print(f"Done. Retained {retained} backup(s) under {destination}{db_name}/")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Stream a pg_dump backup to cloud storage (S3 or Azure Blob)"
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to YAML config file. Omit to read all settings from env vars "
+             "(DATABASE_URL, BACKUP_DESTINATION, BACKUP_KEEP_LAST_N).",
+    )
+    args = parser.parse_args()
+
+    try:
+        backup(args.config)
+    except Exception as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backup_postgres.py
+++ b/scripts/backup_postgres.py
@@ -26,7 +26,7 @@ def _load_config(config_path: str) -> dict:
 def _parse_db_name(db_url: str) -> str:
     name = urlparse(db_url).path.lstrip("/")
     if not name:
-        raise ValueError(f"Could not parse database name from connection string")
+        raise ValueError("Could not parse database name from connection string")
     return name
 
 
@@ -97,7 +97,7 @@ def backup(config_path: str | None = None) -> None:
             f"pg_dump exited {proc.returncode}:\n{stderr_out.decode(errors='replace')}"
         )
 
-    print(f"Upload complete.")
+    print("Upload complete.")
 
     # Prune backups beyond keep_last_n
     fs, root = fsspec.core.url_to_fs(destination, **storage_opts)
@@ -125,7 +125,7 @@ def main() -> None:
         "--config",
         default=None,
         help="Path to YAML config file. Omit to read all settings from env vars "
-             "(DATABASE_URL, BACKUP_DESTINATION, BACKUP_KEEP_LAST_N).",
+        "(DATABASE_URL, BACKUP_DESTINATION, BACKUP_KEEP_LAST_N).",
     )
     args = parser.parse_args()
 

--- a/scripts/backup_postgres.py
+++ b/scripts/backup_postgres.py
@@ -1,9 +1,8 @@
-"""Backup a PostgreSQL database to cloud storage (S3 or Azure Blob) via fsspec.
+"""Backup a PostgreSQL database to Azure Blob Storage via fsspec.
 
 Streams pg_dump stdout directly to the destination — no local disk writes.
-Destination URL controls the backend:
+Destination URL format:
   az://container/prefix/     → Azure Blob (adlfs)
-  s3://bucket/prefix/        → AWS S3 (s3fs)
 """
 
 import argparse
@@ -31,28 +30,24 @@ def _parse_db_name(db_url: str) -> str:
 
 
 def _storage_options(destination: str) -> dict:
-    """Build fsspec storage_options from env vars based on destination URL scheme."""
+    """Build fsspec storage_options from env vars for Azure Blob."""
     scheme = destination.split("://")[0]
-    if scheme in ("az", "abfs"):
-        # AZURE_STORAGE_CONNECTION_STRING takes priority — used for Azurite and
-        # other non-cloud endpoints where the endpoint URL differs from the default.
-        conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
-        if conn_str:
-            return {"connection_string": conn_str}
-        opts = {}
-        account_name = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
-        account_key = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
-        if account_name:
-            opts["account_name"] = account_name
-        if account_key:
-            opts["account_key"] = account_key
-        return opts
-    # S3: boto3 picks up AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY automatically.
-    # AWS_ENDPOINT_URL overrides the endpoint — used for MinIO and other S3-compatible stores.
-    endpoint_url = os.getenv("AWS_ENDPOINT_URL")
-    if endpoint_url:
-        return {"endpoint_url": endpoint_url}
-    return {}
+    if scheme not in ("az", "abfs"):
+        raise ValueError(f"Unsupported destination scheme: {scheme}. Only az:// is supported.")
+    
+    # AZURE_STORAGE_CONNECTION_STRING takes priority — used for Azurite and
+    # other non-cloud endpoints where the endpoint URL differs from the default.
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    if conn_str:
+        return {"connection_string": conn_str}
+    opts = {}
+    account_name = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
+    account_key = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
+    if account_name:
+        opts["account_name"] = account_name
+    if account_key:
+        opts["account_key"] = account_key
+    return opts
 
 
 def backup(config_path: str | None = None) -> None:
@@ -119,7 +114,7 @@ def backup(config_path: str | None = None) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Stream a pg_dump backup to cloud storage (S3 or Azure Blob)"
+        description="Stream a pg_dump backup to Azure Blob Storage"
     )
     parser.add_argument(
         "--config",

--- a/scripts/backup_postgres.py
+++ b/scripts/backup_postgres.py
@@ -33,7 +33,9 @@ def _storage_options(destination: str) -> dict:
     """Build fsspec storage_options from env vars for Azure Blob."""
     scheme = destination.split("://")[0]
     if scheme not in ("az", "abfs"):
-        raise ValueError(f"Unsupported destination scheme: {scheme}. Only az:// or abfs:// are supported.")
+        raise ValueError(
+            f"Unsupported destination scheme: {scheme}. Only az:// or abfs:// are supported."
+        )
 
     # AZURE_STORAGE_CONNECTION_STRING takes priority — used for Azurite and
     # other non-cloud endpoints where the endpoint URL differs from the default.

--- a/scripts/backup_postgres.py
+++ b/scripts/backup_postgres.py
@@ -33,8 +33,8 @@ def _storage_options(destination: str) -> dict:
     """Build fsspec storage_options from env vars for Azure Blob."""
     scheme = destination.split("://")[0]
     if scheme not in ("az", "abfs"):
-        raise ValueError(f"Unsupported destination scheme: {scheme}. Only az:// is supported.")
-    
+        raise ValueError(f"Unsupported destination scheme: {scheme}. Only az:// or abfs:// are supported.")
+
     # AZURE_STORAGE_CONNECTION_STRING takes priority — used for Azurite and
     # other non-cloud endpoints where the endpoint URL differs from the default.
     conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")

--- a/scripts/backup_postgres_dev.sh
+++ b/scripts/backup_postgres_dev.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Run a pg_dump backup against the local docker-compose stack (db + azurite),
+# then download the resulting .dump file to the directory where this script was invoked.
+set -euo pipefail
+
+INVOKE_DIR="$(pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DOCKER_DIR="${REPO_ROOT}/docker"
+
+
+# --- Read credentials from docker/.env (fall back to .env.example defaults) --
+_read_env() {
+    local key=$1 file=$2 default=$3
+    local val
+    val=$(grep "^${key}=" "$file" 2>/dev/null | cut -d= -f2- | head -1)
+    echo "${val:-$default}"
+}
+
+ENV_FILE="${DOCKER_DIR}/.env"
+[[ -f "$ENV_FILE" ]] || ENV_FILE="${DOCKER_DIR}/.env.example"
+
+POSTGRES_USER=$(_read_env POSTGRES_USER "$ENV_FILE" "llmaven-admin")
+POSTGRES_PASSWORD=$(_read_env POSTGRES_PASSWORD "$ENV_FILE" "dbpassword9090")
+POSTGRES_PORT=$(_read_env POSTGRES_PORT "$ENV_FILE" "5432")
+
+# --- Fixed Azurite well-known dev credentials --------------------------------
+# These are public, documented constants — safe to hardcode for local dev.
+AZURITE_CONN_STR="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+BACKUP_CONTAINER="pg-backups"
+DB_NAME="litellm_db"
+
+# --- Set env vars for the backup script --------------------------------------
+export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${DB_NAME}"
+export AZURE_STORAGE_CONNECTION_STRING="$AZURITE_CONN_STR"
+export BACKUP_DESTINATION="az://${BACKUP_CONTAINER}/"
+export BACKUP_KEEP_LAST_N="${BACKUP_KEEP_LAST_N:-7}"
+
+# --- Ensure blob container exists --------------------------------------------
+echo "Ensuring '${BACKUP_CONTAINER}' container exists in Azurite..."
+az storage container create \
+    --name "$BACKUP_CONTAINER" \
+    --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+    --output none
+
+# --- Run backup --------------------------------------------------------------
+echo "Running backup..."
+cd "$REPO_ROOT"
+pixi run -e backup python scripts/backup_postgres.py
+
+# --- Download latest dump to the directory where the script was invoked ------
+echo ""
+echo "Fetching latest backup blob..."
+BLOB_NAME=$(az storage blob list \
+    --container-name "$BACKUP_CONTAINER" \
+    --prefix "${DB_NAME}/" \
+    --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+    --query "[-1].name" \
+    --output tsv)
+
+if [[ -z "$BLOB_NAME" || "$BLOB_NAME" == "None" ]]; then
+    echo "ERROR: No backup blobs found under ${BACKUP_CONTAINER}/${DB_NAME}/" >&2
+    exit 1
+fi
+
+OUT_FILE="${INVOKE_DIR}/$(basename "$BLOB_NAME")"
+echo "Downloading ${BLOB_NAME} → ${OUT_FILE}"
+az storage blob download \
+    --container-name "$BACKUP_CONTAINER" \
+    --name "$BLOB_NAME" \
+    --file "$OUT_FILE" \
+    --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+    --output none
+
+echo "Done! Backup saved to ${OUT_FILE}"
+echo "Inspect with pg_restore --list ${OUT_FILE}"

--- a/scripts/testing.md
+++ b/scripts/testing.md
@@ -13,7 +13,6 @@ Blob emulator).
 brew install libpq
 # libpq is keg-only — add it to PATH for this session (or add to your shell profile)
 export PATH="/opt/homebrew/opt/libpq/bin:$PATH"   # Apple Silicon
-# export PATH="/usr/local/opt/libpq/bin:$PATH"    # Intel Mac
 ```
 
 **Linux (Debian/Ubuntu):**

--- a/scripts/testing.md
+++ b/scripts/testing.md
@@ -1,7 +1,7 @@
 # Testing the PostgreSQL backup script locally
 
-Uses the docker-compose stack (`docker/docker-compose.yml`). Azurite (Azure Blob
-emulator) and MinIO (S3 emulator) are both available.
+Uses the docker-compose stack (`docker/docker-compose.yml`) with Azurite (Azure
+Blob emulator).
 
 ## Prerequisites
 
@@ -127,46 +127,3 @@ az storage blob download \
 
 pg_restore --list /tmp/test.dump | head -20
 ```
-
----
-
-## AWS S3 (MinIO)
-
-MinIO is already running in the stack and the `llmaven` bucket is pre-created by
-the `createbuckets` service.
-
-### 1. Start required services
-
-```bash
-cd docker
-docker compose up -d db minio createbuckets
-```
-
-### 2. Update the destination in the config
-
-```yaml
-pg_backup:
-  destination: "s3://llmaven/pg-backups/"
-```
-
-### 3. Set environment variables
-
-```bash
-export DATABASE_URL="postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@localhost:<POSTGRES_PORT>/<POSTGRES_DB>"
-export AWS_ENDPOINT_URL="http://localhost:9000"
-export AWS_ACCESS_KEY_ID="<MINIO_ROOT_USER from docker/.env>"
-export AWS_SECRET_ACCESS_KEY="<MINIO_ROOT_PASSWORD from docker/.env>"
-```
-
-### 4. Run the backup
-
-```bash
-pixi run -e backup backup
-# or directly:
-pixi run -e backup python scripts/backup_postgres.py --config llmaven-backup-config.yaml
-```
-
-### 5. Verify via MinIO console
-
-Open http://localhost:9001 and log in with the MinIO root credentials. Navigate
-to the `llmaven` bucket to confirm the dump file is present.

--- a/scripts/testing.md
+++ b/scripts/testing.md
@@ -46,21 +46,7 @@ docker compose up -d db azurite
 docker compose ps db azurite  # wait for both to be healthy
 ```
 
-### 2. Create the blob container
-
-Azurite uses fixed well-known dev credentials. `azure-storage-blob` is pulled in
-by `adlfs`:
-
-```bash
-python -c "
-from azure.storage.blob import BlobServiceClient
-cs = 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
-BlobServiceClient.from_connection_string(cs).create_container('pg-backups')
-print('Container created.')
-"
-```
-
-### 3. Set environment variables
+### 2. Set environment variables
 
 Pull DB credentials from `docker/.env`:
 
@@ -69,6 +55,16 @@ export DATABASE_URL="postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@localhost:
 
 # Azurite fixed dev credentials — public, safe to use as-is
 export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+```
+
+### 2. Create the blob container
+
+Azurite uses fixed well-known dev credentials:
+
+```bash
+az storage container create \
+  --name pg-backups \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
 ```
 
 ### 4. Confirm destination in config
@@ -101,12 +97,11 @@ Done. Retained 1 backup(s) under az://pg-backups/llmaven/postgres/
 ### 6. Verify the backup landed
 
 ```bash
-python -c "
-from azure.storage.blob import BlobServiceClient
-cs = 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
-cc = BlobServiceClient.from_connection_string(cs).get_container_client('pg-backups')
-for b in cc.list_blobs(): print(b.name, b.size)
-"
+az storage blob list \
+  --container-name pg-backups \
+  --prefix llmaven/ \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  --output table
 ```
 
 ### 7. Test retention
@@ -118,15 +113,18 @@ Azurite.
 ### 8. Verify the dump is valid
 
 ```bash
-python -c "
-from azure.storage.blob import BlobServiceClient
-cs = 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
-cc = BlobServiceClient.from_connection_string(cs).get_container_client('pg-backups')
-blobs = list(cc.list_blobs(name_starts_with='llmaven/postgres/'))
-data = cc.download_blob(blobs[-1].name).readall()
-open('/tmp/test.dump', 'wb').write(data)
-print('Downloaded', blobs[-1].name)
-"
+BLOB_NAME=$(az storage blob list \
+  --container-name pg-backups \
+  --prefix llmaven/postgres/ \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  --query '[-1].name' -o tsv)
+
+az storage blob download \
+  --container-name pg-backups \
+  --name "$BLOB_NAME" \
+  --file /tmp/test.dump \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+
 pg_restore --list /tmp/test.dump | head -20
 ```
 

--- a/scripts/testing.md
+++ b/scripts/testing.md
@@ -57,7 +57,7 @@ export DATABASE_URL="postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@localhost:
 export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
 ```
 
-### 2. Create the blob container
+### 3. Create the blob container
 
 Azurite uses fixed well-known dev credentials:
 

--- a/scripts/testing.md
+++ b/scripts/testing.md
@@ -1,0 +1,161 @@
+# Testing the PostgreSQL backup script locally
+
+Uses the docker-compose stack (`docker/docker-compose.yml`). Azurite (Azure Blob emulator) and MinIO (S3 emulator) are both available.
+
+## Prerequisites
+
+### PostgreSQL client tools
+
+**macOS:**
+```bash
+brew install libpq
+# libpq is keg-only — add it to PATH for this session (or add to your shell profile)
+export PATH="/opt/homebrew/opt/libpq/bin:$PATH"   # Apple Silicon
+# export PATH="/usr/local/opt/libpq/bin:$PATH"    # Intel Mac
+```
+
+**Linux (Debian/Ubuntu):**
+```bash
+sudo apt-get install -y postgresql-client
+```
+
+### Python dependencies
+
+Activate the pixi backup environment (installs fsspec, adlfs, pyyaml):
+```bash
+pixi run -e backup python --version  # triggers environment solve on first run
+```
+
+Or if running outside pixi:
+```bash
+pip install fsspec adlfs pyyaml
+```
+
+## Azure Blob (Azurite)
+
+### 1. Start required services
+
+```bash
+cd docker
+docker compose up -d db azurite
+docker compose ps db azurite  # wait for both to be healthy
+```
+
+### 2. Create the blob container
+
+Azurite uses fixed well-known dev credentials. `azure-storage-blob` is pulled in by `adlfs`:
+
+```bash
+python -c "
+from azure.storage.blob import BlobServiceClient
+cs = 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
+BlobServiceClient.from_connection_string(cs).create_container('pg-backups')
+print('Container created.')
+"
+```
+
+### 3. Set environment variables
+
+Pull DB credentials from `docker/.env`:
+
+```bash
+export DATABASE_URL="postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@localhost:<POSTGRES_PORT>/<POSTGRES_DB>"
+
+# Azurite fixed dev credentials — public, safe to use as-is
+export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+```
+
+### 4. Confirm destination in config
+
+`llmaven-backup-config.yaml` already has:
+```yaml
+pg_backup:
+  destination: "az://pg-backups/llmaven/"
+```
+No changes needed — this matches the container created above.
+
+### 5. Run the backup
+
+```bash
+pixi run -e backup backup
+# or directly:
+pixi run -e backup python scripts/backup_postgres.py --config llmaven-backup-config.yaml
+```
+
+Expected output:
+```
+Backing up 'postgres' → az://pg-backups/llmaven/postgres/2026-05-08T02-00-00Z.dump
+Upload complete.
+Done. Retained 1 backup(s) under az://pg-backups/llmaven/postgres/
+```
+
+### 6. Verify the backup landed
+
+```bash
+python -c "
+from azure.storage.blob import BlobServiceClient
+cs = 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
+cc = BlobServiceClient.from_connection_string(cs).get_container_client('pg-backups')
+for b in cc.list_blobs(): print(b.name, b.size)
+"
+```
+
+### 7. Test retention
+
+Set `keep_last_n: 2` in the config and run the script three times. On the third run you should see a `Deleted old backup:` line and only 2 files remain in Azurite.
+
+### 8. Verify the dump is valid
+
+```bash
+python -c "
+from azure.storage.blob import BlobServiceClient
+cs = 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
+cc = BlobServiceClient.from_connection_string(cs).get_container_client('pg-backups')
+blobs = list(cc.list_blobs(name_starts_with='llmaven/postgres/'))
+data = cc.download_blob(blobs[-1].name).readall()
+open('/tmp/test.dump', 'wb').write(data)
+print('Downloaded', blobs[-1].name)
+"
+pg_restore --list /tmp/test.dump | head -20
+```
+
+---
+
+## AWS S3 (MinIO)
+
+MinIO is already running in the stack and the `llmaven` bucket is pre-created by the `createbuckets` service.
+
+### 1. Start required services
+
+```bash
+cd docker
+docker compose up -d db minio createbuckets
+```
+
+### 2. Update the destination in the config
+
+```yaml
+pg_backup:
+  destination: "s3://llmaven/pg-backups/"
+```
+
+### 3. Set environment variables
+
+```bash
+export DATABASE_URL="postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@localhost:<POSTGRES_PORT>/<POSTGRES_DB>"
+export AWS_ENDPOINT_URL="http://localhost:9000"
+export AWS_ACCESS_KEY_ID="<MINIO_ROOT_USER from docker/.env>"
+export AWS_SECRET_ACCESS_KEY="<MINIO_ROOT_PASSWORD from docker/.env>"
+```
+
+### 4. Run the backup
+
+```bash
+pixi run -e backup backup
+# or directly:
+pixi run -e backup python scripts/backup_postgres.py --config llmaven-backup-config.yaml
+```
+
+### 5. Verify via MinIO console
+
+Open http://localhost:9001 and log in with the MinIO root credentials. Navigate to the `llmaven` bucket to confirm the dump file is present.

--- a/scripts/testing.md
+++ b/scripts/testing.md
@@ -1,12 +1,14 @@
 # Testing the PostgreSQL backup script locally
 
-Uses the docker-compose stack (`docker/docker-compose.yml`). Azurite (Azure Blob emulator) and MinIO (S3 emulator) are both available.
+Uses the docker-compose stack (`docker/docker-compose.yml`). Azurite (Azure Blob
+emulator) and MinIO (S3 emulator) are both available.
 
 ## Prerequisites
 
 ### PostgreSQL client tools
 
 **macOS:**
+
 ```bash
 brew install libpq
 # libpq is keg-only — add it to PATH for this session (or add to your shell profile)
@@ -15,6 +17,7 @@ export PATH="/opt/homebrew/opt/libpq/bin:$PATH"   # Apple Silicon
 ```
 
 **Linux (Debian/Ubuntu):**
+
 ```bash
 sudo apt-get install -y postgresql-client
 ```
@@ -22,11 +25,13 @@ sudo apt-get install -y postgresql-client
 ### Python dependencies
 
 Activate the pixi backup environment (installs fsspec, adlfs, pyyaml):
+
 ```bash
 pixi run -e backup python --version  # triggers environment solve on first run
 ```
 
 Or if running outside pixi:
+
 ```bash
 pip install fsspec adlfs pyyaml
 ```
@@ -43,7 +48,8 @@ docker compose ps db azurite  # wait for both to be healthy
 
 ### 2. Create the blob container
 
-Azurite uses fixed well-known dev credentials. `azure-storage-blob` is pulled in by `adlfs`:
+Azurite uses fixed well-known dev credentials. `azure-storage-blob` is pulled in
+by `adlfs`:
 
 ```bash
 python -c "
@@ -68,10 +74,12 @@ export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountNam
 ### 4. Confirm destination in config
 
 `llmaven-backup-config.yaml` already has:
+
 ```yaml
 pg_backup:
   destination: "az://pg-backups/llmaven/"
 ```
+
 No changes needed — this matches the container created above.
 
 ### 5. Run the backup
@@ -83,6 +91,7 @@ pixi run -e backup python scripts/backup_postgres.py --config llmaven-backup-con
 ```
 
 Expected output:
+
 ```
 Backing up 'postgres' → az://pg-backups/llmaven/postgres/2026-05-08T02-00-00Z.dump
 Upload complete.
@@ -102,7 +111,9 @@ for b in cc.list_blobs(): print(b.name, b.size)
 
 ### 7. Test retention
 
-Set `keep_last_n: 2` in the config and run the script three times. On the third run you should see a `Deleted old backup:` line and only 2 files remain in Azurite.
+Set `keep_last_n: 2` in the config and run the script three times. On the third
+run you should see a `Deleted old backup:` line and only 2 files remain in
+Azurite.
 
 ### 8. Verify the dump is valid
 
@@ -123,7 +134,8 @@ pg_restore --list /tmp/test.dump | head -20
 
 ## AWS S3 (MinIO)
 
-MinIO is already running in the stack and the `llmaven` bucket is pre-created by the `createbuckets` service.
+MinIO is already running in the stack and the `llmaven` bucket is pre-created by
+the `createbuckets` service.
 
 ### 1. Start required services
 
@@ -158,4 +170,5 @@ pixi run -e backup python scripts/backup_postgres.py --config llmaven-backup-con
 
 ### 5. Verify via MinIO console
 
-Open http://localhost:9001 and log in with the MinIO root credentials. Navigate to the `llmaven` bucket to confirm the dump file is present.
+Open http://localhost:9001 and log in with the MinIO root credentials. Navigate
+to the `llmaven` bucket to confirm the dump file is present.

--- a/src/llmaven/cli.py
+++ b/src/llmaven/cli.py
@@ -43,6 +43,14 @@ infra_app = typer.Typer(
 )
 app.add_typer(infra_app)
 
+# Create subcommand for backup storage infrastructure management
+backup_infra_app = typer.Typer(
+    name="backup-infra",
+    help="Backup storage infrastructure commands",
+    add_completion=False,
+)
+app.add_typer(backup_infra_app)
+
 # Create subcommand for agentic RAG operations
 agentic_app = typer.Typer(
     name="agentic",
@@ -1099,6 +1107,133 @@ def cancel(
         sys.exit(1)
     except Exception as e:
         typer.echo(f"✗ Cancel failed: {e}", err=True)
+        sys.exit(1)
+
+
+@backup_infra_app.command(name="deploy")
+def backup_infra_deploy(
+    config: Optional[str] = typer.Option(
+        "llmaven-backup-config.yaml",
+        "--config",
+        "-c",
+        help="Path to backup configuration file",
+    ),
+    preview: bool = typer.Option(
+        False,
+        "--preview",
+        "-p",
+        is_flag=True,
+        help="Preview changes without deploying",
+    ),
+    auto_approve: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        is_flag=True,
+        help="Automatically approve deployment",
+    ),
+) -> None:
+    """Deploy the backup storage infrastructure to Azure.
+
+    Creates the resource group, storage account, and pg-backups container
+    in an isolated stack. This stack is intentionally separate from the main
+    stack so that backups survive a main-stack destroy.
+
+    Examples:
+        Preview deployment:
+            llmaven backup-infra deploy --preview
+
+        Deploy with auto-approval:
+            llmaven backup-infra deploy --yes
+
+        Deploy with explicit config path:
+            llmaven backup-infra deploy --config llmaven-backup-config.yaml
+    """
+    from pathlib import Path
+
+    from llmaven.deployment.deploy_backup import DeploymentError, deploy_backup_storage
+
+    config_path = Path(config)
+
+    try:
+        deploy_backup_storage(
+            config_path=config_path,
+            preview=preview,
+            auto_approve=auto_approve,
+        )
+    except DeploymentError as e:
+        typer.echo(f"✗ Backup deployment failed: {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        typer.echo(f"✗ Backup deployment failed: {e}", err=True)
+        sys.exit(1)
+
+
+@backup_infra_app.command(name="output")
+def backup_infra_output(
+    config: Optional[str] = typer.Option(
+        "llmaven-backup-config.yaml",
+        "--config",
+        "-c",
+        help="Path to backup configuration file",
+    ),
+    secret: Optional[str] = typer.Option(
+        None,
+        "--secret",
+        help="Name of a secret output to retrieve (revealed in plaintext)",
+    ),
+    name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help="Name of a non-secret output to retrieve",
+    ),
+) -> None:
+    """Print a backup stack output value to stdout.
+
+    Use --secret to retrieve and reveal secret outputs (e.g. connection strings).
+    Use --name for non-secret outputs. Exactly one of --secret or --name is required.
+
+    The value is printed to stdout so it can be captured by a subshell.
+
+    Examples:
+        Retrieve the storage connection string:
+            llmaven backup-infra output \\
+              --config llmaven-backup-config.yaml \\
+              --secret backup_storage_connection_string
+
+        Capture into an environment variable:
+            export BACKUP_STORAGE_CONNECTION_STRING=$(llmaven backup-infra output \\
+              --config llmaven-backup-config.yaml \\
+              --secret backup_storage_connection_string)
+    """
+    from pathlib import Path
+
+    from llmaven.deployment.deploy_backup import DeploymentError, get_backup_stack_output
+
+    if secret is None and name is None:
+        typer.echo("✗ Provide --secret <output-name> or --name <output-name>.", err=True)
+        sys.exit(1)
+    if secret is not None and name is not None:
+        typer.echo("✗ --secret and --name are mutually exclusive.", err=True)
+        sys.exit(1)
+
+    config_path = Path(config)
+    output_name = secret if secret is not None else name
+    reveal = secret is not None
+
+    try:
+        value = get_backup_stack_output(
+            config_path=config_path,
+            output_name=output_name,
+            reveal_secret=reveal,
+        )
+        typer.echo(value)
+    except DeploymentError as e:
+        typer.echo(f"✗ {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        typer.echo(f"✗ Failed to retrieve output: {e}", err=True)
         sys.exit(1)
 
 

--- a/src/llmaven/cli.py
+++ b/src/llmaven/cli.py
@@ -1209,10 +1209,15 @@ def backup_infra_output(
     """
     from pathlib import Path
 
-    from llmaven.deployment.deploy_backup import DeploymentError, get_backup_stack_output
+    from llmaven.deployment.deploy_backup import (
+        DeploymentError,
+        get_backup_stack_output,
+    )
 
     if secret is None and name is None:
-        typer.echo("✗ Provide --secret <output-name> or --name <output-name>.", err=True)
+        typer.echo(
+            "✗ Provide --secret <output-name> or --name <output-name>.", err=True
+        )
         sys.exit(1)
     if secret is not None and name is not None:
         typer.echo("✗ --secret and --name are mutually exclusive.", err=True)

--- a/src/llmaven/deployment/deploy_backup.py
+++ b/src/llmaven/deployment/deploy_backup.py
@@ -1,8 +1,8 @@
 """Deploy LLMaven backup storage infrastructure to Azure.
 
-Uses an existing resource group and provisions the isolated backup storage stack
-(storage account + pg-backups container). Intended to be deployed once,
-independently of the main stack, so that the backups survive a main-stack destroy.
+Provisions the isolated backup storage stack (resource group, storage account,
+and pg-backups container). Intended to be deployed once, independently of the
+main stack, so that the backups survive a main-stack destroy.
 
 After deployment, copy the `backup_storage_connection_string` output value into
 the BACKUP_STORAGE_CONNECTION_STRING environment variable before deploying the

--- a/src/llmaven/deployment/deploy_backup.py
+++ b/src/llmaven/deployment/deploy_backup.py
@@ -56,7 +56,9 @@ def get_backup_stack(config_path: Path) -> auto.Stack:
 
     os.environ.setdefault(
         "PULUMI_BACKEND_URL",
-        PULUMI_BACKEND_URL.format(container=CONTAINER_NAME, storage_account=state_store),
+        PULUMI_BACKEND_URL.format(
+            container=CONTAINER_NAME, storage_account=state_store
+        ),
     )
     os.environ.setdefault("AZURE_STORAGE_ACCOUNT", state_store)
     storage_key = _get_storage_key(rg_name, state_store)
@@ -148,8 +150,12 @@ def deploy_backup_storage(
         if conn_str_output:
             print("Next step — set this before deploying the main stack:")
             print()
-            print("  export BACKUP_STORAGE_CONNECTION_STRING=$(llmaven backup-infra output \\")
-            print(f"    --config {config_path} --secret backup_storage_connection_string)")
+            print(
+                "  export BACKUP_STORAGE_CONNECTION_STRING=$(llmaven backup-infra output \\"
+            )
+            print(
+                f"    --config {config_path} --secret backup_storage_connection_string)"
+            )
             print()
 
     except auto.errors.CommandError as e:
@@ -158,7 +164,9 @@ def deploy_backup_storage(
         raise DeploymentError(f"Backup storage deployment failed: {e}")
 
 
-def get_backup_stack_output(config_path: Path, output_name: str, reveal_secret: bool = False) -> str:
+def get_backup_stack_output(
+    config_path: Path, output_name: str, reveal_secret: bool = False
+) -> str:
     """Print a specific stack output value.
 
     Args:

--- a/src/llmaven/deployment/deploy_backup.py
+++ b/src/llmaven/deployment/deploy_backup.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from pulumi import automation as auto
 
-from .deploy import DeploymentError, _get_storage_key, _run_az_command
+from .deploy import DeploymentError, _get_storage_key
 from ..infrastructure_backup.main import create_backup_storage_program
 
 CONTAINER_NAME = "pulumi-state"

--- a/src/llmaven/deployment/deploy_backup.py
+++ b/src/llmaven/deployment/deploy_backup.py
@@ -1,8 +1,8 @@
 """Deploy LLMaven backup storage infrastructure to Azure.
 
-Provisions the isolated backup storage stack (resource group + storage account +
-pg-backups container). Intended to be deployed once, independently of the main
-stack, so that the backups survive a main-stack destroy.
+Uses an existing resource group and provisions the isolated backup storage stack
+(storage account + pg-backups container). Intended to be deployed once,
+independently of the main stack, so that the backups survive a main-stack destroy.
 
 After deployment, copy the `backup_storage_connection_string` output value into
 the BACKUP_STORAGE_CONNECTION_STRING environment variable before deploying the

--- a/src/llmaven/deployment/deploy_backup.py
+++ b/src/llmaven/deployment/deploy_backup.py
@@ -1,0 +1,190 @@
+"""Deploy LLMaven backup storage infrastructure to Azure.
+
+Provisions the isolated backup storage stack (resource group + storage account +
+pg-backups container). Intended to be deployed once, independently of the main
+stack, so that the backups survive a main-stack destroy.
+
+After deployment, copy the `backup_storage_connection_string` output value into
+the BACKUP_STORAGE_CONNECTION_STRING environment variable before deploying the
+main stack to wire the Container Apps backup job.
+"""
+
+import os
+from pathlib import Path
+
+from pulumi import automation as auto
+
+from .deploy import DeploymentError, _get_storage_key, _run_az_command
+from ..infrastructure_backup.main import create_backup_storage_program
+
+CONTAINER_NAME = "pulumi-state"
+PULUMI_BACKEND_URL = "azblob://{container}?storage_account={storage_account}"
+BACKUP_PROJECT_NAME = "llmaven-backup"
+
+
+def _load_backup_config(config_path: Path) -> dict:
+    import yaml
+
+    if not config_path.exists():
+        raise DeploymentError(f"Backup config file not found: {config_path}")
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def get_backup_stack(config_path: Path) -> auto.Stack:
+    """Get or create the backup storage Pulumi stack.
+
+    Args:
+        config_path: Path to llmaven-backup-config.yaml
+
+    Returns:
+        Stack object
+
+    Raises:
+        DeploymentError: If stack creation fails
+    """
+    cfg = _load_backup_config(config_path)
+    rg_name = cfg["azure"]["resource_group"]
+    state_store = cfg["project"]["pulumi_state_store"]
+    environment = cfg["project"]["environment"]
+    stack_name = f"{BACKUP_PROJECT_NAME}-{environment}"
+
+    if not rg_name or not state_store:
+        raise DeploymentError(
+            "azure.resource_group and project.pulumi_state_store must be set in the backup config."
+        )
+
+    os.environ.setdefault(
+        "PULUMI_BACKEND_URL",
+        PULUMI_BACKEND_URL.format(container=CONTAINER_NAME, storage_account=state_store),
+    )
+    os.environ.setdefault("AZURE_STORAGE_ACCOUNT", state_store)
+    storage_key = _get_storage_key(rg_name, state_store)
+    if storage_key:
+        os.environ.setdefault("AZURE_STORAGE_KEY", storage_key)
+
+    program = create_backup_storage_program(config_path)
+
+    try:
+        stack = auto.create_or_select_stack(
+            stack_name=stack_name,
+            project_name=BACKUP_PROJECT_NAME,
+            program=program,
+        )
+    except Exception as e:
+        raise DeploymentError(f"Failed to create or select backup stack: {e}")
+
+    return stack
+
+
+def deploy_backup_storage(
+    config_path: Path,
+    preview: bool = False,
+    auto_approve: bool = False,
+) -> None:
+    """Deploy the backup storage stack.
+
+    Args:
+        config_path: Path to llmaven-backup-config.yaml
+        preview: Preview changes without deploying
+        auto_approve: Skip confirmation prompt
+
+    Raises:
+        DeploymentError: If deployment fails
+    """
+    print("🗄️  LLMaven Backup Storage Deployment")
+    print()
+
+    cfg = _load_backup_config(config_path)
+    if not cfg.get("project", {}).get("enable_passphrase", False):
+        os.environ.setdefault("PULUMI_CONFIG_PASSPHRASE", "")
+
+    environment = cfg["project"]["environment"]
+    stack_name = f"{BACKUP_PROJECT_NAME}-{environment}"
+
+    print(f"Stack:    {stack_name}")
+    print(f"Location: {cfg['project']['location']}")
+    print()
+
+    try:
+        stack = get_backup_stack(config_path)
+        stack.workspace.install_plugin("azure-native", "v2.0.0")
+
+        if preview:
+            result = stack.preview(on_output=lambda msg: print(msg))
+            print()
+            print(f"Resources to create: {result.change_summary.get('create', 0)}")
+            print(f"Resources to update: {result.change_summary.get('update', 0)}")
+            return
+
+        if not auto_approve:
+            print("⚠️  This will create a storage account for PostgreSQL backups.")
+            print()
+            try:
+                confirm = input("Continue? (yes/no): ").strip().lower()
+                if confirm != "yes":
+                    print("Deployment cancelled.")
+                    return
+            except (KeyboardInterrupt, EOFError):
+                print("\nDeployment cancelled.")
+                return
+
+        up_result = stack.up(on_output=lambda msg: print(msg))
+
+        print()
+        print("=" * 70)
+        print()
+        print("✅ Backup storage deployed successfully!")
+        print()
+
+        if up_result.outputs:
+            print("Outputs:")
+            for key, output in up_result.outputs.items():
+                value = "(secret)" if output.secret else output.value
+                print(f"  {key}: {value}")
+            print()
+
+        conn_str_output = up_result.outputs.get("backup_storage_connection_string")
+        if conn_str_output:
+            print("Next step — set this before deploying the main stack:")
+            print()
+            print("  export BACKUP_STORAGE_CONNECTION_STRING=$(llmaven backup-infra output \\")
+            print(f"    --config {config_path} --secret backup_storage_connection_string)")
+            print()
+
+    except auto.errors.CommandError as e:
+        raise DeploymentError(f"Pulumi command failed: {e}")
+    except Exception as e:
+        raise DeploymentError(f"Backup storage deployment failed: {e}")
+
+
+def get_backup_stack_output(config_path: Path, output_name: str, reveal_secret: bool = False) -> str:
+    """Print a specific stack output value.
+
+    Args:
+        config_path: Path to llmaven-backup-config.yaml
+        output_name: Output key to retrieve
+        reveal_secret: Whether to reveal secret values
+
+    Returns:
+        Output value string
+    """
+    cfg = _load_backup_config(config_path)
+    if not cfg.get("project", {}).get("enable_passphrase", False):
+        os.environ.setdefault("PULUMI_CONFIG_PASSPHRASE", "")
+
+    stack = get_backup_stack(config_path)
+    outputs = stack.outputs()
+
+    if output_name not in outputs:
+        raise DeploymentError(
+            f"Output '{output_name}' not found. Available: {list(outputs.keys())}"
+        )
+
+    output = outputs[output_name]
+    if output.secret and not reveal_secret:
+        raise DeploymentError(
+            f"'{output_name}' is a secret. Use --reveal-secret to show its value."
+        )
+
+    return output.value

--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -276,6 +276,33 @@ class SecurityConfig(BaseModel):
     )
 
 
+class BackupJobConfig(BaseModel):
+    """Container Apps Job configuration for scheduled PostgreSQL backups."""
+
+    enabled: bool = Field(default=False, description="Enable the backup job")
+    image: str = Field(
+        default="ghcr.io/uw-ssec/llmaven-backup:latest",
+        description="Backup container image",
+    )
+    schedule: str = Field(
+        default="0 2 * * *", description="CRON schedule (UTC)"
+    )
+    destination: str = Field(
+        default="az://pg-backups/llmaven/",
+        description="fsspec destination URL (az:// or s3://)",
+    )
+    keep_last_n: int = Field(default=7, ge=1, description="Number of backups to retain")
+    cpu: float = Field(default=0.25, description="CPU cores", ge=0.25)
+    memory: str = Field(default="0.5Gi", description="Memory allocation")
+    replica_timeout: int = Field(
+        default=1800, description="Max job runtime in seconds", ge=60
+    )
+    connection_string_env: str = Field(
+        default="BACKUP_STORAGE_CONNECTION_STRING",
+        description="Env var holding the backup storage account connection string",
+    )
+
+
 class LLMavenConfig(BaseModel):
     """Root configuration model for LLMaven deployment."""
 
@@ -312,6 +339,9 @@ class LLMavenConfig(BaseModel):
     )
     security: SecurityConfig = Field(
         default_factory=SecurityConfig, description="Security configuration"
+    )
+    backup_job: BackupJobConfig = Field(
+        default_factory=BackupJobConfig, description="Scheduled backup job configuration"
     )
     tags: Dict[str, str] = Field(
         default_factory=lambda: {

--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -288,7 +288,7 @@ class BackupJobConfig(BaseModel):
     schedule: str = Field(default="0 10 * * *", description="CRON schedule (UTC)")
     destination: str = Field(
         default="az://pg-backups/llmaven/",
-        description="fsspec destination URL (az:// or s3://)",
+        description="Azure Blob Storage destination URL (az://)",
     )
     keep_last_n: int = Field(default=7, ge=1, description="Number of backups to retain")
     cpu: float = Field(default=0.25, description="CPU cores", ge=0.25)

--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -284,7 +284,8 @@ class BackupJobConfig(BaseModel):
         default="ghcr.io/uw-ssec/llmaven-backup:latest",
         description="Backup container image",
     )
-    schedule: str = Field(default="0 2 * * *", description="CRON schedule (UTC)")
+    # Daily at 10:00 AM UTC — every day of the week, every month
+    schedule: str = Field(default="0 10 * * *", description="CRON schedule (UTC)")
     destination: str = Field(
         default="az://pg-backups/llmaven/",
         description="fsspec destination URL (az:// or s3://)",

--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -297,7 +297,7 @@ class BackupJobConfig(BaseModel):
         default=1800, description="Max job runtime in seconds", ge=60
     )
     connection_string_env: str = Field(
-        default="BACKUP_STORAGE_CONNECTION_STRING",
+        default="LLMAVEN_SECRETS_BACKUP_STORAGE_CONNECTION_STRING",
         description="Env var holding the backup storage account connection string",
     )
 

--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -284,9 +284,7 @@ class BackupJobConfig(BaseModel):
         default="ghcr.io/uw-ssec/llmaven-backup:latest",
         description="Backup container image",
     )
-    schedule: str = Field(
-        default="0 2 * * *", description="CRON schedule (UTC)"
-    )
+    schedule: str = Field(default="0 2 * * *", description="CRON schedule (UTC)")
     destination: str = Field(
         default="az://pg-backups/llmaven/",
         description="fsspec destination URL (az:// or s3://)",
@@ -341,7 +339,8 @@ class LLMavenConfig(BaseModel):
         default_factory=SecurityConfig, description="Security configuration"
     )
     backup_job: BackupJobConfig = Field(
-        default_factory=BackupJobConfig, description="Scheduled backup job configuration"
+        default_factory=BackupJobConfig,
+        description="Scheduled backup job configuration",
     )
     tags: Dict[str, str] = Field(
         default_factory=lambda: {

--- a/src/llmaven/infrastructure/main.py
+++ b/src/llmaven/infrastructure/main.py
@@ -417,13 +417,17 @@ def create_pulumi_program(config_path: Path):
                     "is not set — skipping backup job"
                 )
             else:
+                from urllib.parse import urlparse
+
                 from llmaven.infrastructure.resources import get_connection_string
 
+                db_name = urlparse(os.environ.get("DATABASE_URL", "")).path.lstrip("/")
+                pulumi.log.info(f"Backup target database: {db_name!r}")
                 db_url = get_connection_string(
                     postgres_server.fully_qualified_domain_name,
+                    db_name,
                     config.database.admin_login,
                     admin_password,
-                    "llmaven",
                 )
                 create_backup_job(
                     resource_group_name=resource_group,

--- a/src/llmaven/infrastructure/main.py
+++ b/src/llmaven/infrastructure/main.py
@@ -30,8 +30,10 @@ def create_pulumi_program(config_path: Path):
     def llmaven_infra():
         """Main Pulumi program that deploys all LLMaven infrastructure resources.
 
+        Note that this assumes the resource group already exists. It is created as part of initialize_azure_infra() in src/llmaven/deployment/deploy.py
+
         This function orchestrates the deployment of Azure resources in the following order:
-        1. Resource Group and Virtual Network with subnets
+        1. The Virtual Network with subnets
         2. Key Vault for secrets management
         3. Secrets Manager initialization
         4. PostgreSQL Flexible Server and databases
@@ -41,6 +43,7 @@ def create_pulumi_program(config_path: Path):
         8. Managed Identities for services
         9. Container Apps (MLflow and LiteLLM)
         """
+
         import os
 
         import pulumi

--- a/src/llmaven/infrastructure/main.py
+++ b/src/llmaven/infrastructure/main.py
@@ -41,12 +41,15 @@ def create_pulumi_program(config_path: Path):
         8. Managed Identities for services
         9. Container Apps (MLflow and LiteLLM)
         """
+        import os
+
         import pulumi
         import pulumi_azure_native as azure_native
 
         from llmaven.infrastructure.config.loader import ConfigLoadError, load_config
         from llmaven.infrastructure.resources import (
             SecretsManager,
+            create_backup_job,
             create_container_apps_environment,
             create_databases,
             create_key_vault,
@@ -400,6 +403,35 @@ def create_pulumi_program(config_path: Path):
                     lambda c: f"https://{c.ingress.fqdn}" if c and c.ingress else None
                 ),
             )
+
+        # 9. Backup Container Apps Job
+        if config.backup_job and config.backup_job.enabled:
+            pulumi.log.info("Creating backup Container Apps Job...")
+            storage_conn_str = os.environ.get(config.backup_job.connection_string_env)
+            if not storage_conn_str:
+                pulumi.log.warn(
+                    f"backup_job.enabled=true but {config.backup_job.connection_string_env} "
+                    "is not set — skipping backup job"
+                )
+            else:
+                # Reconstruct DB URL from Pulumi Outputs already in scope
+                db_url = pulumi.Output.all(
+                    postgres_server.fully_qualified_domain_name, admin_password
+                ).apply(
+                    lambda args: (
+                        f"postgresql://{config.database.admin_login}:{args[1]}"
+                        f"@{args[0]}/llmaven"
+                    )
+                )
+                create_backup_job(
+                    resource_group_name=resource_group,
+                    location=location,
+                    managed_environment_id=container_env.id,
+                    db_url=db_url,
+                    storage_conn_str=storage_conn_str,
+                    config=config,
+                    tags=config.tags,
+                )
 
         # Export common outputs
         pulumi.export("resource_group_name", resource_group)

--- a/src/llmaven/infrastructure/main.py
+++ b/src/llmaven/infrastructure/main.py
@@ -417,14 +417,13 @@ def create_pulumi_program(config_path: Path):
                     "is not set — skipping backup job"
                 )
             else:
-                # Reconstruct DB URL from Pulumi Outputs already in scope
-                db_url = pulumi.Output.all(
-                    postgres_server.fully_qualified_domain_name, admin_password
-                ).apply(
-                    lambda args: (
-                        f"postgresql://{config.database.admin_login}:{args[1]}"
-                        f"@{args[0]}/llmaven"
-                    )
+                from llmaven.infrastructure.resources import get_connection_string
+
+                db_url = get_connection_string(
+                    postgres_server.fully_qualified_domain_name,
+                    config.database.admin_login,
+                    admin_password,
+                    "llmaven",
                 )
                 create_backup_job(
                     resource_group_name=resource_group,

--- a/src/llmaven/infrastructure/main.py
+++ b/src/llmaven/infrastructure/main.py
@@ -414,7 +414,10 @@ def create_pulumi_program(config_path: Path):
             if not storage_conn_str:
                 pulumi.log.warn(
                     f"backup_job.enabled=true but {config.backup_job.connection_string_env} "
-                    "is not set — skipping backup job"
+                    "is not set"
+                )
+                raise ValueError(
+                    f"{config.backup_job.connection_string_env} must be set in environment variables to deploy the backup job"
                 )
             else:
                 from urllib.parse import urlparse

--- a/src/llmaven/infrastructure/resources/__init__.py
+++ b/src/llmaven/infrastructure/resources/__init__.py
@@ -1,6 +1,7 @@
 """Pulumi resource modules for Azure infrastructure."""
 
 from .container_apps import (
+    create_backup_job,
     create_container_app_with_key_vault_secrets,
     create_container_apps_environment,
 )
@@ -56,6 +57,7 @@ __all__ = [
     # Container Apps resources
     "create_container_apps_environment",
     "create_container_app_with_key_vault_secrets",
+    "create_backup_job",
     # Key Vault resources
     "create_key_vault",
     "create_secret",

--- a/src/llmaven/infrastructure/resources/container_apps.py
+++ b/src/llmaven/infrastructure/resources/container_apps.py
@@ -11,7 +11,7 @@ import pulumi
 import pulumi_azure_native as azure_native
 from pulumi import Output
 
-from ..config.schema import LLMavenConfig
+from ..config.schema import LLMavenConfig, BackupJobConfig
 
 
 def create_container_apps_environment(
@@ -334,3 +334,99 @@ def create_container_app_with_key_vault_secrets(
     )
 
     return container_app
+
+
+def create_backup_job(
+    resource_group_name: Output[str],
+    location: str,
+    managed_environment_id: Output[str],
+    db_url: Output[str],
+    storage_conn_str: str,
+    config: LLMavenConfig,
+    tags: Dict[str, str],
+) -> azure_native.app.Job:
+    """Create a scheduled Container Apps Job that streams pg_dump to blob storage.
+
+    The job runs inside the existing VNet, giving it private access to PostgreSQL.
+    Both secrets are stored inline (no Key Vault, no managed identity required).
+
+    Args:
+        resource_group_name: Resource group for the job
+        location: Azure region
+        managed_environment_id: Existing Container Apps Environment ID
+        db_url: PostgreSQL connection string as a Pulumi Output
+        storage_conn_str: Backup storage account connection string (plain string,
+                          read from env at deploy time)
+        config: LLMaven configuration
+        tags: Resource tags
+
+    Returns:
+        Job resource
+    """
+    project_name = config.project.name
+    environment = config.project.environment
+    job_cfg: BackupJobConfig = config.backup_job
+
+    job = azure_native.app.Job(
+        f"backup-job-{environment}",
+        resource_group_name=resource_group_name,
+        job_name=f"{project_name}-backup-{environment}",
+        location=location,
+        tags=tags,
+        managed_environment_id=managed_environment_id,
+        configuration=azure_native.app.JobConfigurationArgs(
+            trigger_type=azure_native.app.TriggerType.SCHEDULE,
+            replica_retry_limit=2,
+            replica_timeout=job_cfg.replica_timeout,
+            schedule_trigger_config=azure_native.app.JobConfigurationScheduleTriggerConfigArgs(
+                cron_expression=job_cfg.schedule,
+                parallelism=1,
+                replica_completion_count=1,
+            ),
+            secrets=[
+                azure_native.app.SecretArgs(
+                    name="database-url",
+                    value=db_url,
+                ),
+                azure_native.app.SecretArgs(
+                    name="backup-storage-conn-str",
+                    value=storage_conn_str,
+                ),
+            ],
+        ),
+        template=azure_native.app.JobTemplateArgs(
+            containers=[
+                azure_native.app.ContainerArgs(
+                    name="backup",
+                    image=job_cfg.image,
+                    resources=azure_native.app.ContainerResourcesArgs(
+                        cpu=job_cfg.cpu,
+                        memory=job_cfg.memory,
+                    ),
+                    env=[
+                        azure_native.app.EnvironmentVarArgs(
+                            name="DATABASE_URL",
+                            secret_ref="database-url",
+                        ),
+                        azure_native.app.EnvironmentVarArgs(
+                            name="AZURE_STORAGE_CONNECTION_STRING",
+                            secret_ref="backup-storage-conn-str",
+                        ),
+                        azure_native.app.EnvironmentVarArgs(
+                            name="BACKUP_DESTINATION",
+                            value=job_cfg.destination,
+                        ),
+                        azure_native.app.EnvironmentVarArgs(
+                            name="BACKUP_KEEP_LAST_N",
+                            value=str(job_cfg.keep_last_n),
+                        ),
+                    ],
+                )
+            ],
+        ),
+    )
+
+    pulumi.export(f"backup_job_name_{environment}", job.name)
+    pulumi.export(f"backup_job_schedule_{environment}", job_cfg.schedule)
+
+    return job

--- a/src/llmaven/infrastructure/resources/container_apps.py
+++ b/src/llmaven/infrastructure/resources/container_apps.py
@@ -373,7 +373,7 @@ def create_backup_job(
         job_name=f"{project_name}-backup-{environment}",
         location=location,
         tags=tags,
-        managed_environment_id=managed_environment_id,
+        environment_id=managed_environment_id,
         configuration=azure_native.app.JobConfigurationArgs(
             trigger_type=azure_native.app.TriggerType.SCHEDULE,
             replica_retry_limit=2,

--- a/src/llmaven/infrastructure_backup/README.md
+++ b/src/llmaven/infrastructure_backup/README.md
@@ -1,0 +1,210 @@
+# LLMaven PostgreSQL Backup
+
+Secondary backup safety net for the Azure PostgreSQL Flexible Server. It runs independently of the Azure-native point-in-time backups so that an accidental database deletion (which would also delete those backups) does not result in data loss.
+
+## How it works
+
+```
+┌─────────────────────────────────────────────────┐
+│  Main stack  (rg-llmaven-{env})                 │
+│                                                 │
+│  Container Apps Environment (VNet-integrated)   │
+│    └── Container Apps Job  ──scheduled daily──► │──┐
+│         pg_dump (streams, no disk write)         │  │
+└─────────────────────────────────────────────────┘  │
+                                                      │ az:// connection string
+┌─────────────────────────────────────────────────┐  │
+│  Backup storage stack  (rg-llmaven-backup-{env})│  │
+│                                                 │◄─┘
+│  Storage Account (Standard LRS)                 │
+│    └── pg-backups/                              │
+│         └── llmaven/                            │
+│              └── {db}/{YYYY-MM-DDTHH-MM-SSZ}.dump│
+└─────────────────────────────────────────────────┘
+```
+
+The Container Apps Job runs inside the same VNet as the database, so PostgreSQL does not need a public endpoint. `pg_dump` stdout is streamed directly to Azure Blob Storage via [fsspec](https://filesystem-spec.readthedocs.io/) — no bytes are written to local disk.
+
+### Two Pulumi stacks, intentionally separated
+
+| Stack | Config file | What it owns |
+|---|---|---|
+| **Main** | `llmaven-config.yaml` | Container Apps Job, everything else |
+| **Backup storage** | `llmaven-backup-config.yaml` | Resource group, storage account, `pg-backups` container |
+
+Keeping the storage account in a separate stack means destroying the main stack (e.g. tearing down a dev environment) does not touch the backup data.
+
+### Authentication
+
+Storage access uses the storage account key embedded in a connection string. No role assignments are required anywhere. The connection string is stored as an inline Container Apps Job secret — it never appears in config files or Pulumi state in plain text.
+
+---
+
+## Configuration
+
+Backup job settings live in the main config (`llmaven-config.yaml`) under `backup_job`:
+
+```yaml
+backup_job:
+  enabled: true
+  image: ghcr.io/uw-ssec/llmaven-backup:latest
+  schedule: "0 2 * * *"          # daily at 2am UTC
+  destination: "az://pg-backups/llmaven/"
+  keep_last_n: 7                 # retain the 7 most recent dumps, delete older ones
+  cpu: 0.25
+  memory: 0.5Gi
+  replica_timeout: 1800          # abort if the job runs longer than 30 minutes
+  connection_string_env: BACKUP_STORAGE_CONNECTION_STRING
+```
+
+All fields have defaults; set `enabled: true` to activate.
+
+---
+
+## Operator runbook
+
+### First-time setup
+
+**Step 1 — Deploy the backup storage stack**
+
+```bash
+llmaven backup-infra deploy --config llmaven-backup-config.yaml
+```
+
+This creates the resource group, storage account, and `pg-backups` container in the isolated backup stack. On completion, the stack prints its outputs including `backup_storage_connection_string` (shown as `(secret)`).
+
+**Step 2 — Retrieve the connection string**
+
+```bash
+# Using the llmaven CLI (requires the stack to be deployed):
+llmaven backup-infra output \
+  --config llmaven-backup-config.yaml \
+  --secret backup_storage_connection_string
+
+# Or directly with the Azure CLI:
+az storage account keys list \
+  --resource-group rg-llmaven-backup-dev-westus2 \
+  --account-name <storage-account-name> \
+  --query '[0].value' -o tsv
+```
+
+**Step 3 — Set the connection string in your environment**
+
+```bash
+export BACKUP_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"
+```
+
+**Step 4 — Enable the backup job in the main config**
+
+Add or update `backup_job` in `llmaven-config.yaml`:
+
+```yaml
+backup_job:
+  enabled: true
+```
+
+**Step 5 — Deploy the main stack**
+
+```bash
+llmaven deploy --config llmaven-config.yaml
+```
+
+The job is created in the existing Container Apps Environment and will run on its first scheduled trigger.
+
+---
+
+### Day-to-day
+
+The job runs automatically on the configured schedule (`0 2 * * *` by default). No operator action is required.
+
+Monitor job history in the Azure Portal:
+> Container Apps → Jobs → `llmaven-backup-{env}` → Execution history
+
+Or via the Azure CLI:
+
+```bash
+az containerapp job execution list \
+  --name llmaven-backup-dev \
+  --resource-group rg-llmaven-dev-westus2 \
+  --output table
+```
+
+---
+
+### Trigger a manual backup
+
+```bash
+az containerapp job start \
+  --name llmaven-backup-dev \
+  --resource-group rg-llmaven-dev-westus2
+```
+
+---
+
+### Verify a backup landed
+
+```bash
+az storage blob list \
+  --account-name <backup-storage-account> \
+  --container-name pg-backups \
+  --prefix llmaven/ \
+  --output table \
+  --account-key <key>
+```
+
+---
+
+### Restore from a backup
+
+**Step 1 — Download the dump file**
+
+```bash
+az storage blob download \
+  --account-name <backup-storage-account> \
+  --container-name pg-backups \
+  --name "llmaven/<timestamp>.dump" \
+  --file restore.dump \
+  --account-key <key>
+```
+
+**Step 2 — Inspect the dump (optional)**
+
+```bash
+pg_restore --list restore.dump | head -30
+```
+
+**Step 3 — Restore to the target database**
+
+```bash
+pg_restore \
+  --host <server-fqdn> \
+  --username <admin-login> \
+  --dbname llmaven \
+  --no-owner \
+  --no-privileges \
+  --verbose \
+  restore.dump
+```
+
+`pg_restore` will prompt for the password unless `PGPASSWORD` is set.
+
+---
+
+### Rotate the storage account key
+
+When rotating the storage account key:
+
+1. Generate a new key in the Azure Portal or via the CLI.
+2. Re-export `BACKUP_STORAGE_CONNECTION_STRING` with the new key.
+3. Re-deploy the main stack — this updates the inline Container Apps Job secret:
+
+```bash
+export BACKUP_STORAGE_CONNECTION_STRING="...new connection string..."
+llmaven deploy --config llmaven-config.yaml
+```
+
+---
+
+## Local testing
+
+See [`scripts/testing.md`](../../scripts/testing.md) for instructions on running the backup script locally against Azurite (Azure Blob emulator) and the docker-compose PostgreSQL instance.

--- a/src/llmaven/infrastructure_backup/README.md
+++ b/src/llmaven/infrastructure_backup/README.md
@@ -33,10 +33,10 @@ are written to local disk.
 
 ### Two Pulumi stacks, intentionally separated
 
-| Stack              | Config file                  | What it owns                                                           |
-| ------------------ | ---------------------------- | ---------------------------------------------------------------------- |
-| **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else                                    |
-| **Backup storage** | `llmaven-backup-config.yaml` | Storage account and `pg-backups` container in an existing backup RG    |
+| Stack              | Config file                  | What it owns                                                        |
+| ------------------ | ---------------------------- | ------------------------------------------------------------------- |
+| **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else                                 |
+| **Backup storage** | `llmaven-backup-config.yaml` | Storage account and `pg-backups` container in an existing backup RG |
 
 Keeping the storage account in a separate stack means destroying the main stack
 (e.g. tearing down a dev environment) does not touch the backup data.

--- a/src/llmaven/infrastructure_backup/README.md
+++ b/src/llmaven/infrastructure_backup/README.md
@@ -33,10 +33,10 @@ are written to local disk.
 
 ### Two Pulumi stacks, intentionally separated
 
-| Stack              | Config file                  | What it owns                                            |
-| ------------------ | ---------------------------- | ------------------------------------------------------- |
-| **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else                     |
-| **Backup storage** | `llmaven-backup-config.yaml` | Resource group, storage account, `pg-backups` container |
+| Stack              | Config file                  | What it owns                                                           |
+| ------------------ | ---------------------------- | ---------------------------------------------------------------------- |
+| **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else                                    |
+| **Backup storage** | `llmaven-backup-config.yaml` | Storage account and `pg-backups` container in an existing backup RG    |
 
 Keeping the storage account in a separate stack means destroying the main stack
 (e.g. tearing down a dev environment) does not touch the backup data.

--- a/src/llmaven/infrastructure_backup/README.md
+++ b/src/llmaven/infrastructure_backup/README.md
@@ -38,10 +38,10 @@ are written to local disk.
 | **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else     |
 | **Backup storage** | `llmaven-backup-config.yaml` | Storage account, `pg-backups` container |
 
-The backup storage stack uses an existing resource group (specified in the
-config) and provisions only the storage account and container within it. Keeping
-the storage account in a separate stack means destroying the main stack (e.g.
-tearing down a dev environment) does not touch the backup data.
+The backup storage stack creates its own resource group and provisions the
+storage account and container within it. Keeping everything in a separate stack
+means destroying the main stack (e.g. tearing down a dev environment) does not
+touch the backup data.
 
 ### Authentication
 

--- a/src/llmaven/infrastructure_backup/README.md
+++ b/src/llmaven/infrastructure_backup/README.md
@@ -1,6 +1,9 @@
 # LLMaven PostgreSQL Backup
 
-Secondary backup safety net for the Azure PostgreSQL Flexible Server. It runs independently of the Azure-native point-in-time backups so that an accidental database deletion (which would also delete those backups) does not result in data loss.
+Secondary backup safety net for the Azure PostgreSQL Flexible Server. It runs
+independently of the Azure-native point-in-time backups so that an accidental
+database deletion (which would also delete those backups) does not result in
+data loss.
 
 ## How it works
 
@@ -23,7 +26,10 @@ Secondary backup safety net for the Azure PostgreSQL Flexible Server. It runs in
 └─────────────────────────────────────────────────┘
 ```
 
-The Container Apps Job runs inside the same VNet as the database, so PostgreSQL does not need a public endpoint. `pg_dump` stdout is streamed directly to Azure Blob Storage via [fsspec](https://filesystem-spec.readthedocs.io/) — no bytes are written to local disk.
+The Container Apps Job runs inside the same VNet as the database, so PostgreSQL
+does not need a public endpoint. `pg_dump` stdout is streamed directly to Azure
+Blob Storage via [fsspec](https://filesystem-spec.readthedocs.io/) — no bytes
+are written to local disk.
 
 ### Two Pulumi stacks, intentionally separated
 
@@ -32,17 +38,22 @@ The Container Apps Job runs inside the same VNet as the database, so PostgreSQL 
 | **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else                     |
 | **Backup storage** | `llmaven-backup-config.yaml` | Resource group, storage account, `pg-backups` container |
 
-Keeping the storage account in a separate stack means destroying the main stack (e.g. tearing down a dev environment) does not touch the backup data.
+Keeping the storage account in a separate stack means destroying the main stack
+(e.g. tearing down a dev environment) does not touch the backup data.
 
 ### Authentication
 
-Storage access uses the storage account key embedded in a connection string. No role assignments are required anywhere. The connection string is stored as an inline Container Apps Job secret — it never appears in config files or Pulumi state in plain text.
+Storage access uses the storage account key embedded in a connection string. No
+role assignments are required anywhere. The connection string is stored as an
+inline Container Apps Job secret — it never appears in config files or Pulumi
+state in plain text.
 
 ---
 
 ## Configuration
 
-Backup job settings live in the main config (`llmaven-config.yaml`) under `backup_job`:
+Backup job settings live in the main config (`llmaven-config.yaml`) under
+`backup_job`:
 
 ```yaml
 backup_job:
@@ -71,7 +82,9 @@ All fields have defaults; set `enabled: true` to activate.
 llmaven backup-infra deploy --config llmaven-backup-config.yaml
 ```
 
-This creates the resource group, storage account, and `pg-backups` container in the isolated backup stack. On completion, the stack prints its outputs including `backup_storage_connection_string` (shown as `(secret)`).
+This creates the resource group, storage account, and `pg-backups` container in
+the isolated backup stack. On completion, the stack prints its outputs including
+`backup_storage_connection_string` (shown as `(secret)`).
 
 **Step 2 — Retrieve the connection string**
 
@@ -109,13 +122,15 @@ backup_job:
 llmaven deploy --config llmaven-config.yaml
 ```
 
-The job is created in the existing Container Apps Environment and will run on its first scheduled trigger.
+The job is created in the existing Container Apps Environment and will run on
+its first scheduled trigger.
 
 ---
 
 ### Day-to-day
 
-The job runs automatically on the configured schedule (`0 2 * * *` by default). No operator action is required.
+The job runs automatically on the configured schedule (`0 2 * * *` by default).
+No operator action is required.
 
 Monitor job history in the Azure Portal:
 
@@ -208,4 +223,6 @@ llmaven deploy --config llmaven-config.yaml
 
 ## Local testing
 
-See [`scripts/testing.md`](../../scripts/testing.md) for instructions on running the backup script locally against Azurite (Azure Blob emulator) and the docker-compose PostgreSQL instance.
+See [`scripts/testing.md`](../../scripts/testing.md) for instructions on running
+the backup script locally against Azurite (Azure Blob emulator) and the
+docker-compose PostgreSQL instance.

--- a/src/llmaven/infrastructure_backup/README.md
+++ b/src/llmaven/infrastructure_backup/README.md
@@ -33,13 +33,15 @@ are written to local disk.
 
 ### Two Pulumi stacks, intentionally separated
 
-| Stack              | Config file                  | What it owns                                                        |
-| ------------------ | ---------------------------- | ------------------------------------------------------------------- |
-| **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else                                 |
-| **Backup storage** | `llmaven-backup-config.yaml` | Storage account and `pg-backups` container in an existing backup RG |
+| Stack              | Config file                  | What it owns                                |
+| ------------------ | ---------------------------- | ------------------------------------------- |
+| **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else         |
+| **Backup storage** | `llmaven-backup-config.yaml` | Storage account, `pg-backups` container     |
 
-Keeping the storage account in a separate stack means destroying the main stack
-(e.g. tearing down a dev environment) does not touch the backup data.
+The backup storage stack uses an existing resource group (specified in the
+config) and provisions only the storage account and container within it. Keeping
+the storage account in a separate stack means destroying the main stack (e.g.
+tearing down a dev environment) does not touch the backup data.
 
 ### Authentication
 
@@ -82,8 +84,9 @@ All fields have defaults; set `enabled: true` to activate.
 llmaven backup-infra deploy --config llmaven-backup-config.yaml
 ```
 
-This creates the resource group, storage account, and `pg-backups` container in
-the isolated backup stack. On completion, the stack prints its outputs including
+This provisions the storage account and `pg-backups` container in the isolated
+backup stack (using the existing resource group specified in the config). On
+completion, the stack prints its outputs including
 `backup_storage_connection_string` (shown as `(secret)`).
 
 **Step 2 — Retrieve the connection string**

--- a/src/llmaven/infrastructure_backup/README.md
+++ b/src/llmaven/infrastructure_backup/README.md
@@ -33,10 +33,10 @@ are written to local disk.
 
 ### Two Pulumi stacks, intentionally separated
 
-| Stack              | Config file                  | What it owns                                |
-| ------------------ | ---------------------------- | ------------------------------------------- |
-| **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else         |
-| **Backup storage** | `llmaven-backup-config.yaml` | Storage account, `pg-backups` container     |
+| Stack              | Config file                  | What it owns                            |
+| ------------------ | ---------------------------- | --------------------------------------- |
+| **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else     |
+| **Backup storage** | `llmaven-backup-config.yaml` | Storage account, `pg-backups` container |
 
 The backup storage stack uses an existing resource group (specified in the
 config) and provisions only the storage account and container within it. Keeping

--- a/src/llmaven/infrastructure_backup/README.md
+++ b/src/llmaven/infrastructure_backup/README.md
@@ -10,9 +10,9 @@ Secondary backup safety net for the Azure PostgreSQL Flexible Server. It runs in
 │                                                 │
 │  Container Apps Environment (VNet-integrated)   │
 │    └── Container Apps Job  ──scheduled daily──► │──┐
-│         pg_dump (streams, no disk write)         │  │
+│         pg_dump (streams, no disk write)        │  │
 └─────────────────────────────────────────────────┘  │
-                                                      │ az:// connection string
+                                                     │ az:// connection string
 ┌─────────────────────────────────────────────────┐  │
 │  Backup storage stack  (rg-llmaven-backup-{env})│  │
 │                                                 │◄─┘
@@ -27,9 +27,9 @@ The Container Apps Job runs inside the same VNet as the database, so PostgreSQL 
 
 ### Two Pulumi stacks, intentionally separated
 
-| Stack | Config file | What it owns |
-|---|---|---|
-| **Main** | `llmaven-config.yaml` | Container Apps Job, everything else |
+| Stack              | Config file                  | What it owns                                            |
+| ------------------ | ---------------------------- | ------------------------------------------------------- |
+| **Main**           | `llmaven-config.yaml`        | Container Apps Job, everything else                     |
 | **Backup storage** | `llmaven-backup-config.yaml` | Resource group, storage account, `pg-backups` container |
 
 Keeping the storage account in a separate stack means destroying the main stack (e.g. tearing down a dev environment) does not touch the backup data.
@@ -48,12 +48,12 @@ Backup job settings live in the main config (`llmaven-config.yaml`) under `backu
 backup_job:
   enabled: true
   image: ghcr.io/uw-ssec/llmaven-backup:latest
-  schedule: "0 2 * * *"          # daily at 2am UTC
+  schedule: "0 2 * * *" # daily at 2am UTC
   destination: "az://pg-backups/llmaven/"
-  keep_last_n: 7                 # retain the 7 most recent dumps, delete older ones
+  keep_last_n: 7 # retain the 7 most recent dumps, delete older ones
   cpu: 0.25
   memory: 0.5Gi
-  replica_timeout: 1800          # abort if the job runs longer than 30 minutes
+  replica_timeout: 1800 # abort if the job runs longer than 30 minutes
   connection_string_env: BACKUP_STORAGE_CONNECTION_STRING
 ```
 
@@ -118,6 +118,7 @@ The job is created in the existing Container Apps Environment and will run on it
 The job runs automatically on the configured schedule (`0 2 * * *` by default). No operator action is required.
 
 Monitor job history in the Azure Portal:
+
 > Container Apps → Jobs → `llmaven-backup-{env}` → Execution history
 
 Or via the Azure CLI:

--- a/src/llmaven/infrastructure_backup/main.py
+++ b/src/llmaven/infrastructure_backup/main.py
@@ -1,8 +1,8 @@
 """Pulumi program for the LLMaven backup storage stack.
 
-Provisions a dedicated resource group and storage account for PostgreSQL backup
-dumps. Intentionally minimal — isolated from the main stack so that a main-stack
-destroy does not affect backup data.
+Uses an existing resource group and provisions a storage account for PostgreSQL
+backup dumps. Intentionally minimal — isolated from the main stack so that a
+main-stack destroy does not affect backup data.
 
 Outputs:
     backup_storage_connection_string  — storage account key-based connection

--- a/src/llmaven/infrastructure_backup/main.py
+++ b/src/llmaven/infrastructure_backup/main.py
@@ -42,18 +42,12 @@ def create_backup_storage_program(config_path: Path):
         region_suffix = location[:4].replace("-", "").lower()
         sa_name = f"{project_name.replace('-', '')}{environment}{region_suffix}bk"[:24]
 
-        # 1. Resource Group
-        rg = azure_native.resources.ResourceGroup(
-            f"backup-rg-{environment}",
-            resource_group_name=rg_name,
-            location=location,
-            tags=tags,
-        )
+        # Resource Group should already exist (created by initialize_azure_infra())
 
-        # 2. Storage Account — Standard LRS, no ADLS Gen2 (plain blob storage)
+        # Storage Account — Standard LRS, no ADLS Gen2 (plain blob storage)
         sa = azure_native.storage.StorageAccount(
             f"backup-storage-{environment}",
-            resource_group_name=rg.name,
+            resource_group_name=rg_name,
             account_name=sa_name,
             location=location,
             tags=tags,
@@ -70,7 +64,7 @@ def create_backup_storage_program(config_path: Path):
         # 3. Blob container for pg_dump files
         azure_native.storage.BlobContainer(
             f"pg-backups-container-{environment}",
-            resource_group_name=rg.name,
+            resource_group_name=rg_name,
             account_name=sa.name,
             container_name="pg-backups",
             public_access=azure_native.storage.PublicAccess.NONE,
@@ -79,7 +73,7 @@ def create_backup_storage_program(config_path: Path):
         # 4. Output: connection string (secret) — operator copies this into
         #    BACKUP_STORAGE_CONNECTION_STRING before deploying the main stack.
         key = get_storage_account_key(
-            resource_group_name=rg.name,
+            resource_group_name=rg_name,
             storage_account_name=sa.name,
         )
         conn_str = get_blob_connection_string(
@@ -88,8 +82,10 @@ def create_backup_storage_program(config_path: Path):
         )
 
         pulumi.export("backup_storage_account_name", sa.name)
-        pulumi.export("backup_resource_group", rg.name)
-        pulumi.export("backup_storage_connection_string", pulumi.Output.secret(conn_str))
+        pulumi.export("backup_resource_group", rg_name)
+        pulumi.export(
+            "backup_storage_connection_string", pulumi.Output.secret(conn_str)
+        )
 
         pulumi.log.info("✓ Backup storage provisioned")
 

--- a/src/llmaven/infrastructure_backup/main.py
+++ b/src/llmaven/infrastructure_backup/main.py
@@ -41,12 +41,18 @@ def create_backup_storage_program(config_path: Path):
         region_suffix = location[:4].replace("-", "").lower()
         sa_name = f"{project_name.replace('-', '')}{environment}{region_suffix}bk"[:24]
 
-        # Resource Group should already exist (created by initialize_azure_infra())
+        # Resource Group — created here so it survives a main-stack destroy
+        rg = azure_native.resources.ResourceGroup(
+            "backup-resource-group",
+            resource_group_name=rg_name,
+            location=location,
+            tags=tags,
+        )
 
         # Storage Account — Standard LRS, no ADLS Gen2 (plain blob storage)
         sa = azure_native.storage.StorageAccount(
             f"backup-storage-{environment}",
-            resource_group_name=rg_name,
+            resource_group_name=rg.name,
             account_name=sa_name,
             location=location,
             tags=tags,
@@ -63,7 +69,7 @@ def create_backup_storage_program(config_path: Path):
         # 3. Blob container for pg_dump files
         azure_native.storage.BlobContainer(
             f"pg-backups-container-{environment}",
-            resource_group_name=rg_name,
+            resource_group_name=rg.name,
             account_name=sa.name,
             container_name="pg-backups",
             public_access=azure_native.storage.PublicAccess.NONE,
@@ -72,7 +78,7 @@ def create_backup_storage_program(config_path: Path):
         # 4. Output: connection string (secret) — operator copies this into
         #    BACKUP_STORAGE_CONNECTION_STRING before deploying the main stack.
         key = get_storage_account_key(
-            resource_group_name=rg_name,
+            resource_group_name=rg.name,
             storage_account_name=sa.name,
         )
         conn_str = get_blob_connection_string(
@@ -81,7 +87,7 @@ def create_backup_storage_program(config_path: Path):
         )
 
         pulumi.export("backup_storage_account_name", sa.name)
-        pulumi.export("backup_resource_group", rg_name)
+        pulumi.export("backup_resource_group", rg.name)
         pulumi.export(
             "backup_storage_connection_string", pulumi.Output.secret(conn_str)
         )

--- a/src/llmaven/infrastructure_backup/main.py
+++ b/src/llmaven/infrastructure_backup/main.py
@@ -17,7 +17,6 @@ def create_backup_storage_program(config_path: Path):
     """Return an inline Pulumi program that provisions backup storage."""
 
     def backup_storage():
-        from pathlib import Path as _Path
 
         import pulumi
         import pulumi_azure_native as azure_native

--- a/src/llmaven/infrastructure_backup/main.py
+++ b/src/llmaven/infrastructure_backup/main.py
@@ -1,0 +1,96 @@
+"""Pulumi program for the LLMaven backup storage stack.
+
+Provisions a dedicated resource group and storage account for PostgreSQL backup
+dumps. Intentionally minimal — isolated from the main stack so that a main-stack
+destroy does not affect backup data.
+
+Outputs:
+    backup_storage_connection_string  — storage account key-based connection
+                                        string (secret); pass to the main stack
+                                        as BACKUP_STORAGE_CONNECTION_STRING.
+"""
+
+from pathlib import Path
+
+
+def create_backup_storage_program(config_path: Path):
+    """Return an inline Pulumi program that provisions backup storage."""
+
+    def backup_storage():
+        from pathlib import Path as _Path
+
+        import pulumi
+        import pulumi_azure_native as azure_native
+        import yaml
+
+        from llmaven.infrastructure.resources.storage import (
+            get_blob_connection_string,
+            get_storage_account_key,
+        )
+
+        # Load raw config — backup config uses a lighter schema than main config
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+
+        project_name = cfg["project"]["name"]
+        environment = cfg["project"]["environment"]
+        location = cfg["project"]["location"]
+        rg_name = cfg["azure"]["resource_group"]
+        tags = cfg.get("tags", {})
+
+        # Storage account name: globally unique, lowercase, no hyphens, ≤24 chars
+        region_suffix = location[:4].replace("-", "").lower()
+        sa_name = f"{project_name.replace('-', '')}{environment}{region_suffix}bk"[:24]
+
+        # 1. Resource Group
+        rg = azure_native.resources.ResourceGroup(
+            f"backup-rg-{environment}",
+            resource_group_name=rg_name,
+            location=location,
+            tags=tags,
+        )
+
+        # 2. Storage Account — Standard LRS, no ADLS Gen2 (plain blob storage)
+        sa = azure_native.storage.StorageAccount(
+            f"backup-storage-{environment}",
+            resource_group_name=rg.name,
+            account_name=sa_name,
+            location=location,
+            tags=tags,
+            sku=azure_native.storage.SkuArgs(
+                name=azure_native.storage.SkuName.STANDARD_LRS,
+            ),
+            kind=azure_native.storage.Kind.STORAGE_V2,
+            is_hns_enabled=False,
+            enable_https_traffic_only=True,
+            minimum_tls_version=azure_native.storage.MinimumTlsVersion.TLS1_2,
+            allow_blob_public_access=False,
+        )
+
+        # 3. Blob container for pg_dump files
+        azure_native.storage.BlobContainer(
+            f"pg-backups-container-{environment}",
+            resource_group_name=rg.name,
+            account_name=sa.name,
+            container_name="pg-backups",
+            public_access=azure_native.storage.PublicAccess.NONE,
+        )
+
+        # 4. Output: connection string (secret) — operator copies this into
+        #    BACKUP_STORAGE_CONNECTION_STRING before deploying the main stack.
+        key = get_storage_account_key(
+            resource_group_name=rg.name,
+            storage_account_name=sa.name,
+        )
+        conn_str = get_blob_connection_string(
+            storage_account_name=sa.name,
+            storage_account_key=key,
+        )
+
+        pulumi.export("backup_storage_account_name", sa.name)
+        pulumi.export("backup_resource_group", rg.name)
+        pulumi.export("backup_storage_connection_string", pulumi.Output.secret(conn_str))
+
+        pulumi.log.info("✓ Backup storage provisioned")
+
+    return backup_storage


### PR DESCRIPTION
This pull request introduces a PostgreSQL backup solution and CLI support for managing backup storage infrastructure. The changes enable seamless streaming of database backups directly to Azure Blob, automate retention, and provide both local and CI/CD usage patterns.

**Key changes:**

**1. PostgreSQL Backup Script and Docker Integration**
- Added `scripts/backup_postgres.py`, a Python script that streams `pg_dump` output directly to S3 or Azure Blob storage using fsspec, supports YAML or environment configuration, and prunes old backups according to a retention policy.
- Created `docker/dockerfiles/backup.dockerfile` to package the backup script and dependencies in a minimal Python container.

**2. CI/CD and Workflow Enhancements**
- Updated `.github/workflows/build-services.yml` to build and push the new backup Docker image, trigger builds on backup script changes, and document the backup image in the workflow summary.

**3. Environment and Dependency Management**
- Extended `pixi.toml` to define a dedicated backup environment with required dependencies and a `backup` task for running the script. 
-
**4. CLI Support for Backup Infrastructure Management**
- Added a `backup-infra` command group to the main CLI (`src/llmaven/cli.py`) with `deploy` and `output` subcommands for provisioning and retrieving Azure backup storage resources, supporting preview and output of secrets. 

**5. Documentation and Testing**
- Added `scripts/testing.md` with detailed instructions for local testing against Azurite (Azure Blob emulator)

# Azure Testing
Ran workflow 9 times and verified the newest 7 backups are kept:
<img width="616" height="490" alt="image" src="https://github.com/user-attachments/assets/ea07ce92-d040-4a0b-8183-60e7c9972257" />
<img width="593" height="487" alt="image" src="https://github.com/user-attachments/assets/c1a3dbcd-2208-4bd6-8106-8ddb9cdb2f75" />



Closes: https://github.com/uw-ssec/schmidt-sciences-workshop/issues/5
