### PR TITLE
Fix passing of connection string secrets for backups and logging

### DIFF
--- a/src/llmaven/deployment/deploy_backup.py
+++ b/src/llmaven/deployment/deploy_backup.py
@@ -47,7 +47,8 @@ def get_backup_stack(config_path: Path) -> auto.Stack:
     rg_name = cfg["azure"]["resource_group"]
     state_store = cfg["project"]["pulumi_state_store"]
     environment = cfg["project"]["environment"]
-    stack_name = f"{BACKUP_PROJECT_NAME}-{environment}"
+    project_name = cfg["project"]["name"]
+    stack_name = f"{project_name}-{environment}"
 
     if not rg_name or not state_store:
         raise DeploymentError(
@@ -70,7 +71,7 @@ def get_backup_stack(config_path: Path) -> auto.Stack:
     try:
         stack = auto.create_or_select_stack(
             stack_name=stack_name,
-            project_name=BACKUP_PROJECT_NAME,
+            project_name=project_name,
             program=program,
         )
     except Exception as e:
@@ -102,7 +103,7 @@ def deploy_backup_storage(
         os.environ.setdefault("PULUMI_CONFIG_PASSPHRASE", "")
 
     environment = cfg["project"]["environment"]
-    stack_name = f"{BACKUP_PROJECT_NAME}-{environment}"
+    stack_name = f"{cfg['project']['name']}-{environment}"
 
     print(f"Stack:    {stack_name}")
     print(f"Location: {cfg['project']['location']}")

--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -297,7 +297,6 @@ class BackupJobConfig(BaseModel):
         default=1800, description="Max job runtime in seconds", ge=60
     )
     database: str = Field(
-        default="",
         description="Name of the PostgreSQL database to back up (must match one of database.databases)",
     )
     connection_string_env: str = Field(

--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -249,6 +249,10 @@ class KeyVaultConfig(BaseModel):
     soft_delete_retention_days: int = Field(
         default=90, description="Soft delete retention days", ge=7, le=90
     )
+    enable_soft_delete: bool = Field(default=False, description="Enable soft delete")
+    enable_purge_protection: Optional[bool] = Field(
+        default=None, description="Enable purge protection"
+    )
 
 
 class NetworkSecurityConfig(BaseModel):

--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -297,6 +297,7 @@ class BackupJobConfig(BaseModel):
         default=1800, description="Max job runtime in seconds", ge=60
     )
     database: str = Field(
+        default="",
         description="Name of the PostgreSQL database to back up (must match one of database.databases)",
     )
     connection_string_env: str = Field(
@@ -366,3 +367,12 @@ class LLMavenConfig(BaseModel):
         # Sync project tag with project name
         if "Project" in self.tags:
             self.tags["Project"] = self.project.name
+
+        if (
+            self.backup_job.enabled
+            and self.backup_job.database not in self.database.databases
+        ):
+            raise ValueError(
+                f"backup_job.database '{self.backup_job.database}' is not in "
+                f"database.databases {self.database.databases}"
+            )

--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -296,6 +296,9 @@ class BackupJobConfig(BaseModel):
     replica_timeout: int = Field(
         default=1800, description="Max job runtime in seconds", ge=60
     )
+    database: str = Field(
+        description="Name of the PostgreSQL database to back up (must match one of database.databases)",
+    )
     connection_string_env: str = Field(
         default="LLMAVEN_SECRETS_BACKUP_STORAGE_CONNECTION_STRING",
         description="Env var holding the backup storage account connection string",

--- a/src/llmaven/infrastructure/main.py
+++ b/src/llmaven/infrastructure/main.py
@@ -214,9 +214,11 @@ def create_pulumi_program(config_path: Path):
         )
 
         pulumi.log.info("Creating storage connection string secret...")
-        secrets_manager.create_storage_connection_string_secret(
-            storage_account_name=storage_account.name,
-            storage_account_key=storage_account_key,
+        storage_conn_str_secret = (
+            secrets_manager.create_storage_connection_string_secret(
+                storage_account_name=storage_account.name,
+                storage_account_key=storage_account_key,
+            )
         )
 
         # 5.2. Create blob containers for storage
@@ -336,7 +338,9 @@ def create_pulumi_program(config_path: Path):
                 tags=config.tags,
                 opts=pulumi.ResourceOptions(
                     depends_on=(
-                        [mlflow_kv_access_policy] if mlflow_kv_access_policy else []
+                        [mlflow_kv_access_policy, storage_conn_str_secret]
+                        if mlflow_kv_access_policy
+                        else [storage_conn_str_secret]
                     )
                 ),
             )
@@ -393,7 +397,9 @@ def create_pulumi_program(config_path: Path):
                 tags=config.tags,
                 opts=pulumi.ResourceOptions(
                     depends_on=(
-                        [litellm_kv_access_policy] if litellm_kv_access_policy else []
+                        [litellm_kv_access_policy, storage_conn_str_secret]
+                        if litellm_kv_access_policy
+                        else [storage_conn_str_secret]
                     )
                 ),
                 extra_modules=[adl_logger_path],
@@ -420,26 +426,41 @@ def create_pulumi_program(config_path: Path):
                     f"{config.backup_job.connection_string_env} must be set in environment variables to deploy the backup job"
                 )
             else:
-                from urllib.parse import urlparse
+                backup_managed_identity = create_user_assigned_managed_identity(
+                    name=f"{stack_name}-backup-identity",
+                    resource_group_name=resource_group,
+                    location=location,
+                    tags=config.tags,
+                )
 
-                from llmaven.infrastructure.resources import get_connection_string
+                backup_kv_access_policy = grant_key_vault_access(
+                    key_vault=key_vault,
+                    principal_id=backup_managed_identity.principal_id,
+                    resource_group_name=resource_group,
+                    tenant_id=config.azure.tenant_id,
+                    permissions_level="read",
+                    principal_name="backup-identity",
+                )
 
-                db_name = urlparse(os.environ.get("DATABASE_URL", "")).path.lstrip("/")
-                pulumi.log.info(f"Backup target database: {db_name!r}")
-                db_url = get_connection_string(
-                    postgres_server.fully_qualified_domain_name,
-                    db_name,
-                    config.database.admin_login,
-                    admin_password,
+                db_secret_name = (
+                    f"db-connection-string-{config.backup_job.database}".replace(
+                        "_", "-"
+                    )
+                )
+                pulumi.log.info(
+                    f"Backup target database: {config.backup_job.database!r}"
                 )
                 create_backup_job(
                     resource_group_name=resource_group,
                     location=location,
                     managed_environment_id=container_env.id,
-                    db_url=db_url,
+                    key_vault_uri=key_vault.properties.vault_uri,
+                    key_vault_secret_refs={"DATABASE_URL": db_secret_name},
                     storage_conn_str=storage_conn_str,
+                    managed_identity_id=backup_managed_identity.id,
                     config=config,
                     tags=config.tags,
+                    opts=pulumi.ResourceOptions(depends_on=[backup_kv_access_policy]),
                 )
 
         # Export common outputs

--- a/src/llmaven/infrastructure/main.py
+++ b/src/llmaven/infrastructure/main.py
@@ -180,7 +180,7 @@ def create_pulumi_program(config_path: Path):
 
         # 4.2. Create database connection strings
         pulumi.log.info("Creating database connection strings...")
-        secrets_manager.create_database_connection_strings(
+        conn_str_secrets = secrets_manager.create_database_connection_strings(
             postgres_server_fqdn=postgres_server.fully_qualified_domain_name,
             admin_login=config.database.admin_login,
             admin_password=admin_password,
@@ -390,27 +390,32 @@ def create_pulumi_program(config_path: Path):
                 raise ValueError(
                     f"{config.backup_job.connection_string_env} must be set in environment variables to deploy the backup job"
                 )
-            else:
-                db_secret_name = (
-                    f"db-connection-string-{config.backup_job.database}".replace(
-                        "_", "-"
-                    )
+
+            db_secret_name = (
+                f"db-connection-string-{config.backup_job.database}".replace("_", "-")
+            )
+            # fetch the secret to ensure it exists before deploying the job, which depends on it.
+            db_conn_str_secret = conn_str_secrets.get(db_secret_name, None)
+            if not db_conn_str_secret:
+                raise ValueError(
+                    f"Database connection string secret '{db_secret_name}' not found. Check backup_job.database and database.databases in configuration."
                 )
-                pulumi.log.info(
-                    f"Backup target database: {config.backup_job.database!r}"
-                )
-                create_backup_job(
-                    resource_group_name=resource_group,
-                    location=location,
-                    managed_environment_id=container_env.id,
-                    key_vault_uri=key_vault.properties.vault_uri,
-                    key_vault_secret_refs={"DATABASE_URL": db_secret_name},
-                    storage_conn_str=storage_conn_str,
-                    managed_identity_id=shared_managed_identity.id,
-                    config=config,
-                    tags=config.tags,
-                    opts=pulumi.ResourceOptions(depends_on=[shared_kv_access_policy]),
-                )
+
+            pulumi.log.info(f"Backup target database: {config.backup_job.database!r}")
+            create_backup_job(
+                resource_group_name=resource_group,
+                location=location,
+                managed_environment_id=container_env.id,
+                key_vault_uri=key_vault.properties.vault_uri,
+                key_vault_secret_refs={"DATABASE_URL": db_secret_name},
+                storage_conn_str=storage_conn_str,
+                managed_identity_id=shared_managed_identity.id,
+                config=config,
+                tags=config.tags,
+                opts=pulumi.ResourceOptions(
+                    depends_on=[shared_kv_access_policy, db_conn_str_secret]
+                ),
+            )
 
         # Export common outputs
         pulumi.export("resource_group_name", resource_group)

--- a/src/llmaven/infrastructure/main.py
+++ b/src/llmaven/infrastructure/main.py
@@ -263,54 +263,31 @@ def create_pulumi_program(config_path: Path):
             tags=config.tags,
         )
 
-        # 7.1. Create User-Assigned Managed Identities for Key Vault access
+        # 7.1. Create a single shared managed identity for all container apps.
+        # Using one identity (and therefore one AccessPolicy) avoids the known issue
+        # where multiple concurrent AccessPolicy resources on the same vault can cause
+        # the Azure updateAccessPolicy(replace) operation to wipe out other policies.
         pulumi.log.info("Creating user-assigned managed identities...")
         from llmaven.infrastructure.resources import (
             create_user_assigned_managed_identity,
             grant_key_vault_access,
         )
 
-        # 7.1.1. Create managed identity for MLflow
-        mlflow_managed_identity = None
-        mlflow_kv_access_policy = None
-        if config.mlflow and config.mlflow.enabled:
-            mlflow_managed_identity = create_user_assigned_managed_identity(
-                name=f"{stack_name}-mlflow-identity",
-                resource_group_name=resource_group,
-                location=location,
-                tags=config.tags,
-            )
+        shared_managed_identity = create_user_assigned_managed_identity(
+            name=f"{stack_name}-apps-identity",
+            resource_group_name=resource_group,
+            location=location,
+            tags=config.tags,
+        )
 
-            # Grant Key Vault access to the managed identity
-            mlflow_kv_access_policy = grant_key_vault_access(
-                key_vault=key_vault,
-                principal_id=mlflow_managed_identity.principal_id,
-                resource_group_name=resource_group,
-                tenant_id=config.azure.tenant_id,
-                permissions_level="read",
-                principal_name="mlflow-identity",
-            )
-
-        # 7.1.2. Create managed identity for LiteLLM
-        litellm_managed_identity = None
-        litellm_kv_access_policy = None
-        if config.litellm and config.litellm.enabled:
-            litellm_managed_identity = create_user_assigned_managed_identity(
-                name=f"{stack_name}-litellm-identity",
-                resource_group_name=resource_group,
-                location=location,
-                tags=config.tags,
-            )
-
-            # Grant Key Vault access to the managed identity
-            litellm_kv_access_policy = grant_key_vault_access(
-                key_vault=key_vault,
-                principal_id=litellm_managed_identity.principal_id,
-                resource_group_name=resource_group,
-                tenant_id=config.azure.tenant_id,
-                permissions_level="read",
-                principal_name="litellm-identity",
-            )
+        shared_kv_access_policy = grant_key_vault_access(
+            key_vault=key_vault,
+            principal_id=shared_managed_identity.principal_id,
+            resource_group_name=resource_group,
+            tenant_id=config.azure.tenant_id,
+            permissions_level="read",
+            principal_name="apps-identity",
+        )
 
         # 8. Deploy Container Apps
 
@@ -332,16 +309,10 @@ def create_pulumi_program(config_path: Path):
                 env_vars=config.mlflow.env_vars,
                 key_vault=key_vault,
                 key_vault_secret_refs=config.mlflow.key_vault_secret_refs,
-                managed_identity_id=(
-                    mlflow_managed_identity.id if mlflow_managed_identity else None
-                ),
+                managed_identity_id=shared_managed_identity.id,
                 tags=config.tags,
                 opts=pulumi.ResourceOptions(
-                    depends_on=(
-                        [mlflow_kv_access_policy, storage_conn_str_secret]
-                        if mlflow_kv_access_policy
-                        else [storage_conn_str_secret]
-                    )
+                    depends_on=[shared_kv_access_policy, storage_conn_str_secret]
                 ),
             )
 
@@ -391,16 +362,10 @@ def create_pulumi_program(config_path: Path):
                 key_vault=key_vault,
                 key_vault_secret_refs=config.litellm.key_vault_secret_refs,
                 config_file=config_file_path,
-                managed_identity_id=(
-                    litellm_managed_identity.id if litellm_managed_identity else None
-                ),
+                managed_identity_id=shared_managed_identity.id,
                 tags=config.tags,
                 opts=pulumi.ResourceOptions(
-                    depends_on=(
-                        [litellm_kv_access_policy, storage_conn_str_secret]
-                        if litellm_kv_access_policy
-                        else [storage_conn_str_secret]
-                    )
+                    depends_on=[shared_kv_access_policy, storage_conn_str_secret]
                 ),
                 extra_modules=[adl_logger_path],
             )
@@ -426,22 +391,6 @@ def create_pulumi_program(config_path: Path):
                     f"{config.backup_job.connection_string_env} must be set in environment variables to deploy the backup job"
                 )
             else:
-                backup_managed_identity = create_user_assigned_managed_identity(
-                    name=f"{stack_name}-backup-identity",
-                    resource_group_name=resource_group,
-                    location=location,
-                    tags=config.tags,
-                )
-
-                backup_kv_access_policy = grant_key_vault_access(
-                    key_vault=key_vault,
-                    principal_id=backup_managed_identity.principal_id,
-                    resource_group_name=resource_group,
-                    tenant_id=config.azure.tenant_id,
-                    permissions_level="read",
-                    principal_name="backup-identity",
-                )
-
                 db_secret_name = (
                     f"db-connection-string-{config.backup_job.database}".replace(
                         "_", "-"
@@ -457,10 +406,10 @@ def create_pulumi_program(config_path: Path):
                     key_vault_uri=key_vault.properties.vault_uri,
                     key_vault_secret_refs={"DATABASE_URL": db_secret_name},
                     storage_conn_str=storage_conn_str,
-                    managed_identity_id=backup_managed_identity.id,
+                    managed_identity_id=shared_managed_identity.id,
                     config=config,
                     tags=config.tags,
-                    opts=pulumi.ResourceOptions(depends_on=[backup_kv_access_policy]),
+                    opts=pulumi.ResourceOptions(depends_on=[shared_kv_access_policy]),
                 )
 
         # Export common outputs

--- a/src/llmaven/infrastructure/resources/container_apps.py
+++ b/src/llmaven/infrastructure/resources/container_apps.py
@@ -432,10 +432,13 @@ def create_backup_job(
                         memory=job_cfg.memory,
                     ),
                     env=[
-                        azure_native.app.EnvironmentVarArgs(
-                            name="DATABASE_URL",
-                            secret_ref=key_vault_secret_refs["DATABASE_URL"],
-                        ),
+                        *[
+                            azure_native.app.EnvironmentVarArgs(
+                                name=env_var_name.upper().replace("-", "_"),
+                                secret_ref=secret_name,
+                            )
+                            for env_var_name, secret_name in key_vault_secret_refs.items()
+                        ],
                         azure_native.app.EnvironmentVarArgs(
                             name="AZURE_STORAGE_CONNECTION_STRING",
                             secret_ref="backup-storage-conn-str",

--- a/src/llmaven/infrastructure/resources/container_apps.py
+++ b/src/llmaven/infrastructure/resources/container_apps.py
@@ -340,25 +340,33 @@ def create_backup_job(
     resource_group_name: Output[str],
     location: str,
     managed_environment_id: Output[str],
-    db_url: Output[str],
+    key_vault_uri: Output[str],
+    key_vault_secret_refs: Dict[str, str],
     storage_conn_str: str,
     config: LLMavenConfig,
     tags: Dict[str, str],
+    managed_identity_id: Optional[Output[str]] = None,
+    opts: Optional[pulumi.ResourceOptions] = None,
 ) -> azure_native.app.Job:
     """Create a scheduled Container Apps Job that streams pg_dump to blob storage.
 
     The job runs inside the existing VNet, giving it private access to PostgreSQL.
-    Both secrets are stored inline (no Key Vault, no managed identity required).
+    The database connection string is sourced from Key Vault via a managed identity.
+    The backup storage connection string is stored inline (separate storage stack,
+    not accessible via the main Key Vault).
 
     Args:
         resource_group_name: Resource group for the job
         location: Azure region
         managed_environment_id: Existing Container Apps Environment ID
-        db_url: PostgreSQL connection string as a Pulumi Output
+        key_vault_uri: Key Vault URI for secret references
+        key_vault_secret_refs: Map of env var name to Key Vault secret name
         storage_conn_str: Backup storage account connection string (plain string,
                           read from env at deploy time)
         config: LLMaven configuration
         tags: Resource tags
+        managed_identity_id: Resource ID of user-assigned managed identity with Key Vault access
+        opts: Pulumi resource options
 
     Returns:
         Job resource
@@ -367,13 +375,36 @@ def create_backup_job(
     environment = config.project.environment
     job_cfg: BackupJobConfig = config.backup_job
 
+    identity_ref = managed_identity_id if managed_identity_id else "system"
+    kv_secrets = [
+        azure_native.app.SecretArgs(
+            name=secret_name,
+            key_vault_url=key_vault_uri.apply(
+                lambda uri, sn=secret_name: f"{uri.rstrip('/')}/secrets/{sn}"
+            ),
+            identity=identity_ref,
+        )
+        for secret_name in key_vault_secret_refs.values()
+    ]
+
     job = azure_native.app.Job(
         f"backup-job-{environment}",
+        opts=opts,
         resource_group_name=resource_group_name,
         job_name=f"{project_name}-backup-{environment}",
         location=location,
         tags=tags,
         environment_id=managed_environment_id,
+        identity=azure_native.app.ManagedServiceIdentityArgs(
+            type=(
+                azure_native.app.ManagedServiceIdentityType.SYSTEM_ASSIGNED_USER_ASSIGNED
+                if managed_identity_id
+                else azure_native.app.ManagedServiceIdentityType.SYSTEM_ASSIGNED
+            ),
+            user_assigned_identities=(
+                [managed_identity_id] if managed_identity_id else None
+            ),
+        ),
         configuration=azure_native.app.JobConfigurationArgs(
             trigger_type=azure_native.app.TriggerType.SCHEDULE,
             replica_retry_limit=2,
@@ -384,10 +415,7 @@ def create_backup_job(
                 replica_completion_count=1,
             ),
             secrets=[
-                azure_native.app.SecretArgs(
-                    name="database-url",
-                    value=db_url,
-                ),
+                *kv_secrets,
                 azure_native.app.SecretArgs(
                     name="backup-storage-conn-str",
                     value=storage_conn_str,
@@ -406,7 +434,7 @@ def create_backup_job(
                     env=[
                         azure_native.app.EnvironmentVarArgs(
                             name="DATABASE_URL",
-                            secret_ref="database-url",
+                            secret_ref=key_vault_secret_refs["DATABASE_URL"],
                         ),
                         azure_native.app.EnvironmentVarArgs(
                             name="AZURE_STORAGE_CONNECTION_STRING",

--- a/src/llmaven/infrastructure/resources/key_vault.py
+++ b/src/llmaven/infrastructure/resources/key_vault.py
@@ -139,8 +139,9 @@ def create_key_vault(
             enable_rbac_authorization=False,
             access_policies=access_policies if access_policies else None,
             # Soft delete configuration
-            enable_soft_delete=False,
-            # soft_delete_retention_in_days=kv_config.soft_delete_retention_days,
+            enable_soft_delete=kv_config.enable_soft_delete,
+            soft_delete_retention_in_days=kv_config.soft_delete_retention_days,
+            enable_purge_protection=kv_config.enable_purge_protection,
             # Network ACLs
             network_acls=azure_native.keyvault.NetworkRuleSetArgs(
                 bypass=azure_native.keyvault.NetworkRuleBypassOptions.AZURE_SERVICES,

--- a/src/llmaven/infrastructure_backup/main.py
+++ b/src/llmaven/infrastructure_backup/main.py
@@ -51,7 +51,7 @@ def create_backup_storage_program(config_path: Path):
 
         # Storage Account — Standard LRS, no ADLS Gen2 (plain blob storage)
         sa = azure_native.storage.StorageAccount(
-            f"backup-storage-{environment}",
+            f"{project_name}-{environment}",
             resource_group_name=rg.name,
             account_name=sa_name,
             location=location,
@@ -68,7 +68,7 @@ def create_backup_storage_program(config_path: Path):
 
         # 3. Blob container for pg_dump files
         azure_native.storage.BlobContainer(
-            f"pg-backups-container-{environment}",
+            f"pg-{project_name}-{environment}",
             resource_group_name=rg.name,
             account_name=sa.name,
             container_name="pg-backups",


### PR DESCRIPTION
### Backup Job Configuration and Deployment Enhancements:

* Adds a required `database` field to the `BackupJobConfig` schema, making the target database explicit and configurable.
* Refactors the backup job deployment to reference the target database connection string from Azure Key Vault using the managed identity, instead of constructing the connection string at deploy time. 
* Ensures the storage connection string secret is created and passed as a dependency to relevant resources, improving deployment reliability. 
* Added validation for the backup database name to exist as one of the databases:

```
🔍 Validating configuration: ../llmaven-deploy/azure/dev/llmaven-config.yaml

1. Configuration Syntax
   ✗ Configuration validation failed:
     Configuration validation failed:
  : Value error, backup_job.database 'litellm_db22' is not in database.databases ['llmaven', 'mlflow_db', 'litellm_db']

❌ Configuration validation failed. Fix errors and try again.
✗ Deployment failed: Configuration validation failed. Fix errors above and try again.
```

### Managed Identity and Key Vault Access Improvements:

**Context:** `azure_native.keyvault.AccessPolicy`
uses `AccessPolicyUpdateKindReplace` for **both create AND update** operations — see
[`custom_keyvault_accesspolicy.go`](https://github.com/pulumi/pulumi-azure-native/blob/master/provider/pkg/resources/customresources/custom_keyvault_accesspolicy.go).
`replace` calls Azure's `updateAccessPolicy(replace)` API which **replaces ALL existing
access policies on the vault** with only the single policy entry in that resource. With
three `AccessPolicy` resources, the last one to be created/updated becomes the only
surviving policy.

**Fix:**

* Replace multiple managed identities for container apps (MLflow, LiteLLM, etc.) with a single shared managed identity, simplifying identity management and avoiding Azure Key Vault access policy conflicts. All container apps now use this shared identity for Key Vault access. 
* Updates container app deployments to depend on the shared managed identity and its Key Vault access policy, ensuring correct resource provisioning order.

