### PR TITLE
fix: repair test_generate_endpoint and test_retrieve_endpoint (#78)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,7 @@ jobs:
             --tb=short \
             --color=yes \
             --ignore=tests/agentic/ \
-            --ignore=tests/v1/ \
-            || echo "Core tests completed with status: $?"
+            --ignore=tests/v1/
 
       - name: Run agentic tests (excluding CLI integration tests)
         run: |

--- a/tests/infrastructure/test_cli_env_file_validation.py
+++ b/tests/infrastructure/test_cli_env_file_validation.py
@@ -7,6 +7,7 @@ in PR #79 (exists, file_okay, dir_okay=False, readable, resolve_path).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,6 +15,14 @@ import pytest
 from typer.testing import CliRunner
 
 from llmaven.cli import app
+
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI color escape codes so substring asserts survive Typer's colorized output."""
+    return _ANSI_ESCAPE_RE.sub("", text)
 
 
 @pytest.fixture()
@@ -31,7 +40,7 @@ class TestInfraValidateEnvFile:
         )
 
         assert result.exit_code == 2
-        assert "Invalid value for '--env-file'" in result.output
+        assert "Invalid value for '--env-file'" in _strip_ansi(result.output)
 
     def test_rejects_env_file_that_is_a_directory(
         self, runner: CliRunner, tmp_path: Path
@@ -45,7 +54,7 @@ class TestInfraValidateEnvFile:
         )
 
         assert result.exit_code == 2
-        assert "Invalid value for '--env-file'" in result.output
+        assert "Invalid value for '--env-file'" in _strip_ansi(result.output)
 
     @patch("llmaven.deployment.validate.validate_config")
     def test_accepts_valid_env_file_and_passes_path_through(
@@ -95,7 +104,7 @@ class TestInfraDeployEnvFile:
         )
 
         assert result.exit_code == 2
-        assert "Invalid value for '--env-file'" in result.output
+        assert "Invalid value for '--env-file'" in _strip_ansi(result.output)
 
     def test_rejects_env_file_that_is_a_directory(
         self, runner: CliRunner, tmp_path: Path
@@ -109,7 +118,7 @@ class TestInfraDeployEnvFile:
         )
 
         assert result.exit_code == 2
-        assert "Invalid value for '--env-file'" in result.output
+        assert "Invalid value for '--env-file'" in _strip_ansi(result.output)
 
     @patch("llmaven.deployment.deploy.deploy_infrastructure")
     def test_accepts_valid_env_file_and_passes_path_through(

--- a/tests/infrastructure/test_cli_extract.py
+++ b/tests/infrastructure/test_cli_extract.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from datetime import date
 import json
 import os
+import re
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -19,6 +20,14 @@ from click.testing import Result
 from typer.testing import CliRunner
 
 from llmaven.cli import _serialize_to_jsonl, _utc_date_to_epoch_ms, app
+
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI color escape codes so substring asserts survive Typer's colorized output."""
+    return _ANSI_ESCAPE_RE.sub("", text)
 
 
 class TestSerializeToJsonl:
@@ -58,13 +67,17 @@ def invoke_extract(
 
 class TestInfraExtract:
     def test_rejects_invalid_date_format(self, runner: CliRunner):
-        result = invoke_extract(runner, from_date="2026-99-01", to_date="2026-01-02")
+        result = invoke_extract(
+            runner, from_date="2026-99-01", to_date="2026-01-02", source=None
+        )
 
         assert result.exit_code == 1
         assert "Invalid date format" in result.output
 
     def test_rejects_inverted_date_range(self, runner: CliRunner):
-        result = invoke_extract(runner, from_date="2026-01-03", to_date="2026-01-02")
+        result = invoke_extract(
+            runner, from_date="2026-01-03", to_date="2026-01-02", source=None
+        )
 
         assert result.exit_code == 1
         assert "--from must be <= --to" in result.output
@@ -82,7 +95,7 @@ class TestInfraExtract:
         )
 
         assert result.exit_code == 2
-        assert "Invalid value for '--out'" in result.output
+        assert "Invalid value for '--out'" in _strip_ansi(result.output)
 
     def test_mkdir_failure_exits(self, runner: CliRunner, tmp_path: Path):
         base_dir = tmp_path / "no-write"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,11 +1,13 @@
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
+
 from llmaven.main import app
 
 client = TestClient(app)
 
 
-# Define test cases
 @pytest.mark.parametrize(
     "prompt,generation_model,expected_status",
     [
@@ -17,20 +19,27 @@ client = TestClient(app)
         ),
     ],
 )
-def test_generate_endpoint(prompt, generation_model, expected_status):
-    """
-    Test the text generation API endpoint.
-    """
-    payload = {"prompt": prompt, "generation_model": generation_model}
+def test_generate_endpoint(
+    prompt: str, generation_model: str, expected_status: int
+) -> None:
+    """Verify the generate endpoint contract without invoking a real LLM."""
+    fake_response = {"answer": f"mocked answer for: {prompt}", "status_code": 200}
 
-    response = client.post("/api/generate/", json=payload)
+    with patch(
+        "llmaven.v1.endpoints.generate.generate_answer",
+        return_value=fake_response,
+    ) as mock_generate:
+        response = client.post(
+            "/v1/generate",
+            json={"prompt": prompt, "generation_model": generation_model},
+        )
 
     assert response.status_code == expected_status
-    assert "answer" in response.json()
-    assert isinstance(response.json()["answer"], str)
-    assert len(response.json()["answer"]) > 0  # Ensure the model generates text
-
-    print(f"✅ Test passed for prompt: {prompt}")
+    body = response.json()
+    assert "answer" in body
+    assert isinstance(body["answer"], str)
+    assert len(body["answer"]) > 0
+    mock_generate.assert_called_once_with(prompt, generation_model)
 
 
 if __name__ == "__main__":

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,10 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
+
 from llmaven.main import app
 
 client = TestClient(app)
 
-# Sample documents for testing
 sample_documents = [
     {
         "page_content": "FastAPI is a modern web framework for building APIs with Python.",
@@ -17,7 +19,6 @@ sample_documents = [
 ]
 
 
-# Define test cases
 @pytest.mark.parametrize(
     "query,expected_status",
     [
@@ -25,32 +26,49 @@ sample_documents = [
         ("Explain vector databases", 200),
     ],
 )
-def test_retrieve_endpoint(query, expected_status):
-    """
-    Test the retrieval API endpoint.
-    """
+def test_retrieve_endpoint(query: str, expected_status: int) -> None:
+    """Verify the retrieve endpoint contract without spinning up Qdrant or embeddings."""
+    fake_response = {
+        "docs": [
+            {"metadata": doc["metadata"], "page_content": doc["page_content"][:500]}
+            for doc in sample_documents
+        ],
+        "status_code": 200,
+    }
+
+    embedding_model = "sentence-transformers/all-MiniLM-L12-v2"
     payload = {
         "documents": sample_documents,
         "query": query,
         "existing_collection": None,
         "existing_qdrant_path": None,
-        "embedding_model": "sentence-transformers/all-MiniLM-L12-v2",
+        "embedding_model": embedding_model,
     }
 
-    response = client.post("/api/retrieve/", json=payload)
+    with patch(
+        "llmaven.v1.endpoints.retrieve.perform_retrieval",
+        return_value=fake_response,
+    ) as mock_retrieve:
+        response = client.post("/v1/retrieve", json=payload)
 
     assert response.status_code == expected_status
-    assert "docs" in response.json()
-    assert isinstance(response.json()["docs"], list)
-    assert response.json()["status_code"] == 200
-
-    retrieved_docs = response.json()["docs"]
-    assert len(retrieved_docs) > 0  # Ensure that some documents are retrieved
-
-    for doc in retrieved_docs:
+    body = response.json()
+    assert "docs" in body
+    assert isinstance(body["docs"], list)
+    assert body["status_code"] == 200
+    assert len(body["docs"]) > 0
+    for doc in body["docs"]:
         assert "metadata" in doc
         assert "page_content" in doc
-        assert len(doc["page_content"]) > 0  # Check content preview is non-empty
+        assert len(doc["page_content"]) > 0
+
+    mock_retrieve.assert_called_once_with(
+        sample_documents,
+        query,
+        None,
+        None,
+        embedding_model,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The endpoint tests were posting to /api/generate/ and /api/retrieve/, but the v1 router mounts those endpoints at /v1/generate and /v1/retrieve, so every request 404'd. They also tried to invoke the real OLMo-2 model and a live Qdrant vector store, which is not viable in CI.

- Point requests at /v1/generate and /v1/retrieve.
- Patch generate_answer and perform_retrieval so the tests verify the endpoint contract without loading transformers or starting Qdrant (matches the pattern in tests/v1/test_agentic_endpoints.py).
- Drop the '|| echo' swallow in ci.yml so a failing core test actually fails the workflow, as the issue requested.