### PR TITLE
feat: add --no-zip flag to infra extract (#87)

### DIFF
--- a/src/llmaven/cli.py
+++ b/src/llmaven/cli.py
@@ -669,10 +669,12 @@ def _prepare_extract_output_file(
     source: "ExtractSource",
     from_date: str,
     to_date: str,
+    use_zip: bool = True,
 ) -> Path:
     use_default_path = output_file is None
     filename_prefix = "llmaven_"
-    filename_suffix = f"_{from_date}_to_{to_date}.zip"
+    base_suffix = f"_{from_date}_to_{to_date}"
+    filename_suffix = f"{base_suffix}.zip" if use_zip else base_suffix
 
     if source.value == ExtractSource.litellm:
         path = output_file or Path(
@@ -685,9 +687,17 @@ def _prepare_extract_output_file(
     else:
         _fail_extract(f"Source is not supported: {source}")
 
-    # Guard only for the default path (Typer can't validate a value that wasn't provided)
-    if use_default_path and path.exists() and path.is_dir():
-        _fail_extract(f"Default output path is a directory: {path}")
+    # Ensure the output path's type matches the chosen mode (zip vs directory).
+    if path.exists():
+        if use_zip and path.is_dir():
+            _fail_extract(
+                f"Output path is a directory but zip mode is enabled: {path}. "
+                "Pass --no-zip to write JSONL files into a directory."
+            )
+        if not use_zip and path.is_file():
+            _fail_extract(
+                f"Output path is a file but --no-zip writes to a directory: {path}"
+            )
 
     # If user provided --out, ensure parent exists (argument parsing doesn’t create directories)
     if not use_default_path:
@@ -703,14 +713,60 @@ def _prepare_extract_output_file(
     return path
 
 
+class _ExtractWriter:
+    """Write per-day JSONL entries to either a zip archive or a directory.
+
+    Why: lets the extract pipeline stay shape-identical whether `--no-zip` is
+    used or not, instead of branching on every writestr call.
+    """
+
+    def __init__(self, output_path: Path, *, use_zip: bool) -> None:
+        self._output_path = output_path
+        self._use_zip = use_zip
+        self._zipf_ctx = None
+        self._zipf = None
+
+    def __enter__(self) -> "_ExtractWriter":
+        if self._use_zip:
+            import zipfile
+
+            self._zipf_ctx = zipfile.ZipFile(
+                self._output_path, mode="w", compression=zipfile.ZIP_DEFLATED
+            )
+            # Use the __enter__ return value so callers (and test mocks) see the
+            # post-__enter__ object, matching a plain `with zipfile.ZipFile(...)`.
+            self._zipf = self._zipf_ctx.__enter__()
+        else:
+            # If the directory previously existed and the user confirmed overwrite,
+            # remove its contents so stale files don't linger alongside new output.
+            if self._output_path.exists() and self._output_path.is_dir():
+                for child in self._output_path.iterdir():
+                    if child.is_file():
+                        child.unlink()
+            self._output_path.mkdir(parents=True, exist_ok=True)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._zipf_ctx is not None:
+            self._zipf_ctx.__exit__(exc_type, exc, tb)
+            self._zipf_ctx = None
+            self._zipf = None
+
+    def writestr(self, name: str, data: str) -> None:
+        if self._zipf is not None:
+            self._zipf.writestr(name, data)
+        else:
+            (self._output_path / name).write_text(data, encoding="utf-8")
+
+
 def _extract_litellm_logs(
     start_date_obj: "date",
     end_date_obj: "date",
     output_file: Path,
     env_file: Optional[Path],
+    use_zip: bool = True,
 ) -> None:
     import json
-    import zipfile
 
     import httpx
 
@@ -726,10 +782,7 @@ def _extract_litellm_logs(
 
     total_records = 0
 
-    # TODO: Make zipfile output optional (https://github.com/uw-ssec/llmaven/issues/87).
-    with zipfile.ZipFile(
-        output_file, mode="w", compression=zipfile.ZIP_DEFLATED
-    ) as zipf:
+    with _ExtractWriter(output_file, use_zip=use_zip) as zipf:
         # TODO: Add retry logic (https://github.com/uw-ssec/llmaven/issues/88).
         with httpx.Client(timeout=30.0) as http_client:
             current_date = start_date_obj
@@ -882,8 +935,8 @@ def _extract_mlflow_logs(
     end_date_obj: "date",
     output_file: Path,
     env_file: Optional[Path],
+    use_zip: bool = True,
 ) -> None:
-    import zipfile
     from collections import defaultdict
 
     import mlflow
@@ -917,9 +970,7 @@ def _extract_mlflow_logs(
     total_records = 0
     total_files_written = 0
 
-    with zipfile.ZipFile(
-        output_file, mode="w", compression=zipfile.ZIP_DEFLATED
-    ) as zipf:
+    with _ExtractWriter(output_file, use_zip=use_zip) as zipf:
         current_date = start_date_obj
 
         # Partition the export by UTC day using half-open windows [D, D+1).
@@ -1011,12 +1062,21 @@ def extract(
     output_file: Optional[Path] = typer.Option(
         None,
         "--out",
-        help="Output zip file path",
-        dir_okay=False,
+        help="Output path (zip file, or directory when --no-zip is used)",
+        dir_okay=True,
         file_okay=True,
         writable=True,
         resolve_path=True,
         path_type=Path,
+    ),
+    no_zip: bool = typer.Option(
+        False,
+        "--no-zip",
+        help=(
+            "Write raw JSONL files into a directory instead of bundling them "
+            "into a zip archive. Useful for small date ranges where unzipping "
+            "is just an extra step."
+        ),
     ),
     env_file: Optional[Path] = ENV_FILE_OPTION,
 ) -> None:
@@ -1047,12 +1107,15 @@ def extract(
     if start_date_obj > end_date_obj:
         _fail_extract("--from must be <= --to")
 
+    use_zip = not no_zip
+
     # Validate output file
     output_file = _prepare_extract_output_file(
         output_file,
         source,
         from_date,
         to_date,
+        use_zip=use_zip,
     )
 
     if source == ExtractSource.litellm:
@@ -1061,6 +1124,7 @@ def extract(
             end_date_obj,
             output_file,
             env_file,
+            use_zip=use_zip,
         )
     elif source == ExtractSource.mlflow:
         _extract_mlflow_logs(
@@ -1068,6 +1132,7 @@ def extract(
             end_date_obj,
             output_file,
             env_file,
+            use_zip=use_zip,
         )
     # else: source is validated in the initial check.
 

--- a/tests/infrastructure/test_cli_extract.py
+++ b/tests/infrastructure/test_cli_extract.py
@@ -45,6 +45,7 @@ def invoke_extract(
     source: str | None,
     output_file: Path | None = None,
     input: str | None = None,
+    no_zip: bool = False,
 ) -> Result:
     args = ["infra", "extract"]
     if source is not None:
@@ -52,6 +53,8 @@ def invoke_extract(
     args += ["--from", from_date, "--to", to_date]
     if output_file is not None:
         args += ["--out", str(output_file)]
+    if no_zip:
+        args += ["--no-zip"]
 
     return runner.invoke(app, args, input=input)
 
@@ -69,7 +72,9 @@ class TestInfraExtract:
         assert result.exit_code == 1
         assert "--from must be <= --to" in result.output
 
-    def test_rejects_output_directory(self, runner: CliRunner, tmp_path: Path):
+    def test_rejects_output_directory_in_zip_mode(
+        self, runner: CliRunner, tmp_path: Path
+    ):
         out_dir = tmp_path / "output-dir"
         out_dir.mkdir()
 
@@ -81,8 +86,26 @@ class TestInfraExtract:
             output_file=out_dir,
         )
 
-        assert result.exit_code == 2
-        assert "Invalid value for '--out'" in result.output
+        assert result.exit_code == 1
+        assert "Output path is a directory but zip mode is enabled" in result.output
+
+    def test_rejects_file_output_in_no_zip_mode(
+        self, runner: CliRunner, tmp_path: Path
+    ):
+        out_file = tmp_path / "already-a-file"
+        out_file.write_text("preexisting", encoding="utf-8")
+
+        result = invoke_extract(
+            runner,
+            from_date="2026-01-01",
+            to_date="2026-01-01",
+            source=None,
+            output_file=out_file,
+            no_zip=True,
+        )
+
+        assert result.exit_code == 1
+        assert "--no-zip writes to a directory" in result.output
 
     def test_mkdir_failure_exits(self, runner: CliRunner, tmp_path: Path):
         base_dir = tmp_path / "no-write"
@@ -233,6 +256,78 @@ class TestInfraExtract:
         assert payload1 == ""
 
         assert "1 total records" in result.output
+
+    @patch(
+        "llmaven.cli._get_llmaven_secrets",
+        return_value={"litellm-master-key": "mk", "litellm-base-url": "http://litellm"},
+    )
+    @patch("httpx.Client")
+    def test_no_zip_writes_jsonl_files_into_directory(
+        self,
+        mock_httpx_client_cls,
+        _mock_secrets,
+        runner: CliRunner,
+        tmp_path: Path,
+    ):
+        output_dir = tmp_path / "spend-logs"
+
+        resp1 = Mock()
+        resp1.raise_for_status.return_value = None
+        resp1.json.return_value = [
+            {"request_id": "a", "startTime": "2026-01-01T00:00:00Z"}
+        ]
+
+        resp2 = Mock()
+        resp2.raise_for_status.return_value = None
+        resp2.json.return_value = []
+
+        http_client = Mock()
+        http_client.get.side_effect = [resp1, resp2]
+        mock_httpx_client_cls.return_value.__enter__.return_value = http_client
+
+        result = invoke_extract(
+            runner,
+            from_date="2026-01-01",
+            to_date="2026-01-02",
+            source=None,
+            output_file=output_dir,
+            no_zip=True,
+        )
+
+        assert result.exit_code == 0
+        assert output_dir.is_dir()
+
+        day1 = output_dir / "litellm_spend_logs_2026-01-01.jsonl"
+        day2 = output_dir / "litellm_spend_logs_2026-01-02.jsonl"
+        assert day1.exists()
+        assert day2.exists()
+
+        day1_text = day1.read_text(encoding="utf-8")
+        assert '"request_id": "a"' in day1_text
+        assert day2.read_text(encoding="utf-8") == ""
+
+    def test_no_zip_default_path_has_no_zip_suffix(
+        self, runner: CliRunner, tmp_path: Path
+    ):
+        # Force resolution path: we just want the typer-side handling to accept
+        # --no-zip without exploding before any extraction runs.
+        with patch("llmaven.cli._extract_litellm_logs") as mock_litellm, patch(
+            "llmaven.cli._prepare_extract_output_file",
+            return_value=tmp_path / "stub",
+        ) as mock_prepare:
+            result = invoke_extract(
+                runner,
+                from_date="2026-01-01",
+                to_date="2026-01-01",
+                source=None,
+                no_zip=True,
+            )
+
+        assert result.exit_code == 0
+        mock_prepare.assert_called_once()
+        assert mock_prepare.call_args.kwargs["use_zip"] is False
+        mock_litellm.assert_called_once()
+        assert mock_litellm.call_args.kwargs["use_zip"] is False
 
     @patch(
         "llmaven.cli._get_llmaven_secrets",

--- a/tests/infrastructure/test_cli_extract.py
+++ b/tests/infrastructure/test_cli_extract.py
@@ -311,10 +311,13 @@ class TestInfraExtract:
     ):
         # Force resolution path: we just want the typer-side handling to accept
         # --no-zip without exploding before any extraction runs.
-        with patch("llmaven.cli._extract_litellm_logs") as mock_litellm, patch(
-            "llmaven.cli._prepare_extract_output_file",
-            return_value=tmp_path / "stub",
-        ) as mock_prepare:
+        with (
+            patch("llmaven.cli._extract_litellm_logs") as mock_litellm,
+            patch(
+                "llmaven.cli._prepare_extract_output_file",
+                return_value=tmp_path / "stub",
+            ) as mock_prepare,
+        ):
             result = invoke_extract(
                 runner,
                 from_date="2026-01-01",


### PR DESCRIPTION
For small date ranges, requiring users to unzip the output afterwards is just an extra step. This adds an opt-in way to write the per-day JSONL files directly into a directory instead of bundling them in a zip archive.

Changes:
- Add --no-zip option to 'infra extract'. Default behavior (zip) is preserved.
- Introduce _ExtractWriter context manager that abstracts the per-day writestr API over either zipfile.ZipFile or a plain directory, so the litellm and mlflow pipelines stay shape-identical in both modes.
- Update _prepare_extract_output_file to validate the output path type against the chosen mode and to drop the .zip suffix from the default filename when --no-zip is used.
- Relax the typer --out constraint to dir_okay=True so users can pass a directory path under --no-zip. The directory-vs-file validation is now done in code with a clearer message.

Tests:
- Replace test_rejects_output_directory with two clearer variants covering both zip-vs-directory mismatch cases.
- Add a happy-path test that runs extract --no-zip end-to-end and asserts the per-day .jsonl files land directly in the chosen directory.
- Add a test that --no-zip flows through to _prepare_extract_output_file and _extract_litellm_logs with use_zip=False.