### PR TITLE
feat: retry transient HTTP failures during litellm spend log extract …

### DIFF
--- a/src/llmaven/cli.py
+++ b/src/llmaven/cli.py
@@ -703,6 +703,72 @@ def _prepare_extract_output_file(
     return path
 
 
+class _TransientHTTPError(Exception):
+    """Marker raised internally so the retry helper knows a response should be retried."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+# Retry config for transient HTTP failures (5xx + 429) and connection errors.
+# Exposed at module scope so tests can monkey-patch a no-wait variant.
+_RETRY_MAX_ATTEMPTS = 5
+_RETRY_WAIT_MULTIPLIER = 1.0
+_RETRY_WAIT_MIN_SECONDS = 1.0
+_RETRY_WAIT_MAX_SECONDS = 10.0
+
+
+def _is_transient_http_status(status_code: int) -> bool:
+    return status_code == 429 or 500 <= status_code < 600
+
+
+def _http_get_with_retry(
+    client,
+    *,
+    url: str,
+    params: dict,
+    headers: dict,
+):
+    """Issue an HTTP GET, retrying on transient HTTP failures and connection errors.
+
+    Retries on:
+      - httpx.RequestError (connect timeouts, DNS failures, etc.)
+      - HTTP 429 (rate limited)
+      - HTTP 5xx (server errors)
+
+    Non-retryable HTTP errors (e.g. 4xx other than 429) surface immediately
+    via raise_for_status().
+    """
+    import httpx
+    import tenacity
+
+    retryer = tenacity.Retrying(
+        retry=tenacity.retry_if_exception_type(
+            (_TransientHTTPError, httpx.RequestError)
+        ),
+        stop=tenacity.stop_after_attempt(_RETRY_MAX_ATTEMPTS),
+        wait=tenacity.wait_exponential(
+            multiplier=_RETRY_WAIT_MULTIPLIER,
+            min=_RETRY_WAIT_MIN_SECONDS,
+            max=_RETRY_WAIT_MAX_SECONDS,
+        ),
+        reraise=True,
+    )
+
+    def _attempt():
+        resp = client.get(url, params=params, headers=headers)
+        if _is_transient_http_status(resp.status_code):
+            raise _TransientHTTPError(
+                f"transient HTTP {resp.status_code} from {url}",
+                status_code=resp.status_code,
+            )
+        resp.raise_for_status()
+        return resp
+
+    return retryer(_attempt)
+
+
 def _extract_litellm_logs(
     start_date_obj: "date",
     end_date_obj: "date",
@@ -730,7 +796,6 @@ def _extract_litellm_logs(
     with zipfile.ZipFile(
         output_file, mode="w", compression=zipfile.ZIP_DEFLATED
     ) as zipf:
-        # TODO: Add retry logic (https://github.com/uw-ssec/llmaven/issues/88).
         with httpx.Client(timeout=30.0) as http_client:
             current_date = start_date_obj
             while current_date <= end_date_obj:
@@ -744,9 +809,13 @@ def _extract_litellm_logs(
                 }
 
                 try:
-                    resp = http_client.get(endpoint, params=params, headers=headers)
-                    resp.raise_for_status()
-                except httpx.HTTPError as exc:
+                    resp = _http_get_with_retry(
+                        http_client,
+                        url=endpoint,
+                        params=params,
+                        headers=headers,
+                    )
+                except (_TransientHTTPError, httpx.HTTPError) as exc:
                     _fail_extract(f"LiteLLM /spend/logs failed for {date_str}: {exc}")
 
                 try:

--- a/tests/infrastructure/test_cli_extract.py
+++ b/tests/infrastructure/test_cli_extract.py
@@ -372,7 +372,7 @@ class TestExtractLiteLLMRetry:
     def _status(code):
         resp = Mock()
         resp.status_code = code
-        # raise_for_status only matters if we don't pre-empt with our transient check
+        # raise_for_status only matters if we don't preempt with our transient check
         resp.raise_for_status.side_effect = __import__("httpx").HTTPStatusError(
             f"{code}", request=Mock(), response=Mock(status_code=code)
         )

--- a/tests/infrastructure/test_cli_extract.py
+++ b/tests/infrastructure/test_cli_extract.py
@@ -373,9 +373,7 @@ class TestExtractLiteLLMRetry:
         resp = Mock()
         resp.status_code = code
         # raise_for_status only matters if we don't pre-empt with our transient check
-        resp.raise_for_status.side_effect = __import__(
-            "httpx"
-        ).HTTPStatusError(
+        resp.raise_for_status.side_effect = __import__("httpx").HTTPStatusError(
             f"{code}", request=Mock(), response=Mock(status_code=code)
         )
         return resp

--- a/tests/infrastructure/test_cli_extract.py
+++ b/tests/infrastructure/test_cli_extract.py
@@ -183,6 +183,7 @@ class TestInfraExtract:
 
         # httpx client mock
         resp1 = Mock()
+        resp1.status_code = 200
         resp1.raise_for_status.return_value = None
         resp1.json.return_value = [
             {
@@ -193,6 +194,7 @@ class TestInfraExtract:
         ]
 
         resp2 = Mock()
+        resp2.status_code = 200
         resp2.raise_for_status.return_value = None
         resp2.json.return_value = []  # no records day 2
 
@@ -251,6 +253,7 @@ class TestInfraExtract:
         output_file = tmp_path / "out.zip"
 
         resp = Mock()
+        resp.status_code = 401
         import httpx
 
         resp.raise_for_status.side_effect = httpx.HTTPStatusError(
@@ -290,6 +293,7 @@ class TestInfraExtract:
         output_file = tmp_path / "out.zip"
 
         resp = Mock()
+        resp.status_code = 200
         resp.raise_for_status.return_value = None
         resp.json.side_effect = json.JSONDecodeError("bad", "doc", 0)
 
@@ -326,6 +330,7 @@ class TestInfraExtract:
         output_file = tmp_path / "out.zip"
 
         resp = Mock()
+        resp.status_code = 200
         resp.raise_for_status.return_value = None
         resp.json.return_value = {"not": "a list"}
 
@@ -344,6 +349,196 @@ class TestInfraExtract:
 
         assert result.exit_code == 1
         assert "Invalid JSON response for 2026-01-01" in result.output
+
+
+class TestExtractLiteLLMRetry:
+    """Verify retry behavior on transient HTTP failures (issue #88)."""
+
+    @pytest.fixture(autouse=True)
+    def _fast_retries(self, monkeypatch):
+        monkeypatch.setattr("llmaven.cli._RETRY_WAIT_MULTIPLIER", 0)
+        monkeypatch.setattr("llmaven.cli._RETRY_WAIT_MIN_SECONDS", 0)
+        monkeypatch.setattr("llmaven.cli._RETRY_WAIT_MAX_SECONDS", 0)
+
+    @staticmethod
+    def _ok(records):
+        resp = Mock()
+        resp.status_code = 200
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = records
+        return resp
+
+    @staticmethod
+    def _status(code):
+        resp = Mock()
+        resp.status_code = code
+        # raise_for_status only matters if we don't pre-empt with our transient check
+        resp.raise_for_status.side_effect = __import__(
+            "httpx"
+        ).HTTPStatusError(
+            f"{code}", request=Mock(), response=Mock(status_code=code)
+        )
+        return resp
+
+    @patch(
+        "llmaven.cli._get_llmaven_secrets",
+        return_value={"litellm-master-key": "mk", "litellm-base-url": "http://litellm"},
+    )
+    @patch("zipfile.ZipFile")
+    @patch("httpx.Client")
+    def test_succeeds_first_try_no_retry(
+        self,
+        mock_httpx_client_cls,
+        mock_zip_cls,
+        _mock_secrets,
+        runner: CliRunner,
+        tmp_path: Path,
+    ):
+        http_client = Mock()
+        http_client.get.return_value = self._ok([{"request_id": "a"}])
+        mock_httpx_client_cls.return_value.__enter__.return_value = http_client
+        mock_zip_cls.return_value.__enter__.return_value = Mock()
+
+        result = invoke_extract(
+            runner,
+            from_date="2026-01-01",
+            to_date="2026-01-01",
+            source=None,
+            output_file=tmp_path / "out.zip",
+        )
+
+        assert result.exit_code == 0
+        assert http_client.get.call_count == 1
+
+    @patch(
+        "llmaven.cli._get_llmaven_secrets",
+        return_value={"litellm-master-key": "mk", "litellm-base-url": "http://litellm"},
+    )
+    @patch("zipfile.ZipFile")
+    @patch("httpx.Client")
+    def test_retries_on_503_then_succeeds(
+        self,
+        mock_httpx_client_cls,
+        mock_zip_cls,
+        _mock_secrets,
+        runner: CliRunner,
+        tmp_path: Path,
+    ):
+        http_client = Mock()
+        http_client.get.side_effect = [
+            self._status(503),
+            self._status(503),
+            self._ok([{"request_id": "a"}]),
+        ]
+        mock_httpx_client_cls.return_value.__enter__.return_value = http_client
+        mock_zip_cls.return_value.__enter__.return_value = Mock()
+
+        result = invoke_extract(
+            runner,
+            from_date="2026-01-01",
+            to_date="2026-01-01",
+            source=None,
+            output_file=tmp_path / "out.zip",
+        )
+
+        assert result.exit_code == 0
+        assert http_client.get.call_count == 3
+
+    @patch(
+        "llmaven.cli._get_llmaven_secrets",
+        return_value={"litellm-master-key": "mk", "litellm-base-url": "http://litellm"},
+    )
+    @patch("zipfile.ZipFile")
+    @patch("httpx.Client")
+    def test_retries_on_429_then_succeeds(
+        self,
+        mock_httpx_client_cls,
+        mock_zip_cls,
+        _mock_secrets,
+        runner: CliRunner,
+        tmp_path: Path,
+    ):
+        http_client = Mock()
+        http_client.get.side_effect = [
+            self._status(429),
+            self._ok([]),
+        ]
+        mock_httpx_client_cls.return_value.__enter__.return_value = http_client
+        mock_zip_cls.return_value.__enter__.return_value = Mock()
+
+        result = invoke_extract(
+            runner,
+            from_date="2026-01-01",
+            to_date="2026-01-01",
+            source=None,
+            output_file=tmp_path / "out.zip",
+        )
+
+        assert result.exit_code == 0
+        assert http_client.get.call_count == 2
+
+    @patch(
+        "llmaven.cli._get_llmaven_secrets",
+        return_value={"litellm-master-key": "mk", "litellm-base-url": "http://litellm"},
+    )
+    @patch("zipfile.ZipFile")
+    @patch("httpx.Client")
+    def test_does_not_retry_on_401(
+        self,
+        mock_httpx_client_cls,
+        mock_zip_cls,
+        _mock_secrets,
+        runner: CliRunner,
+        tmp_path: Path,
+    ):
+        http_client = Mock()
+        http_client.get.return_value = self._status(401)
+        mock_httpx_client_cls.return_value.__enter__.return_value = http_client
+        mock_zip_cls.return_value.__enter__.return_value = Mock()
+
+        result = invoke_extract(
+            runner,
+            from_date="2026-01-01",
+            to_date="2026-01-01",
+            source=None,
+            output_file=tmp_path / "out.zip",
+        )
+
+        assert result.exit_code == 1
+        assert http_client.get.call_count == 1
+        assert "LiteLLM /spend/logs failed" in result.output
+
+    @patch(
+        "llmaven.cli._get_llmaven_secrets",
+        return_value={"litellm-master-key": "mk", "litellm-base-url": "http://litellm"},
+    )
+    @patch("zipfile.ZipFile")
+    @patch("httpx.Client")
+    def test_exhausts_retries_on_persistent_503(
+        self,
+        mock_httpx_client_cls,
+        mock_zip_cls,
+        _mock_secrets,
+        runner: CliRunner,
+        tmp_path: Path,
+    ):
+        http_client = Mock()
+        http_client.get.return_value = self._status(503)
+        mock_httpx_client_cls.return_value.__enter__.return_value = http_client
+        mock_zip_cls.return_value.__enter__.return_value = Mock()
+
+        result = invoke_extract(
+            runner,
+            from_date="2026-01-01",
+            to_date="2026-01-01",
+            source=None,
+            output_file=tmp_path / "out.zip",
+        )
+
+        assert result.exit_code == 1
+        # max_attempts = 5
+        assert http_client.get.call_count == 5
+        assert "transient HTTP 503" in result.output
 
 
 class MockPagedList(list):


### PR DESCRIPTION
…(#88)

LiteLLM's /spend/logs endpoint can return 429 (rate limited) or 5xx mid-extraction, and connection errors are also possible over long date ranges. A single transient failure currently aborts the whole extraction, forcing the user to restart from scratch.

Changes:
- New _http_get_with_retry helper using tenacity (already a project dependency). Retries on httpx.RequestError, HTTP 429, and HTTP 5xx. Exponential backoff: min 1s, max 10s, up to 5 attempts.
- Retry policy parameters exposed as module-level constants so tests can monkey-patch them to zero for fast runs.
- Internal _TransientHTTPError marker keeps the retry trigger explicit and easy to reason about.
- Non-transient HTTP errors (e.g. 401, 404) still surface immediately via raise_for_status, no retries.
- Updated _extract_litellm_logs to call the helper instead of doing a raw GET, and to handle _TransientHTTPError alongside httpx.HTTPError when retries are exhausted.

Tests:
- New TestExtractLiteLLMRetry class covering: success on first try, retry-then-success on 503, retry-then-success on 429, no retry on 401, and exhaustion after the configured max attempts.
- Existing happy-path / error tests for litellm extract had to set resp.status_code explicitly (the retry helper inspects it), so added that to four pre-existing tests.