### PR TITLE
refactor: dedupe get_llmaven_secrets across the codebase (#89)

### DIFF
--- a/src/llmaven/cli.py
+++ b/src/llmaven/cli.py
@@ -615,7 +615,6 @@ def _get_llmaven_secrets(env_file: Optional[Path]) -> dict:
     """Wrapper to keep secrets import local and easy to mock in tests."""
     from llmaven.infrastructure.utils.secrets import get_llmaven_secrets
 
-    # TODO: Deduplicate the get_llmaven_secrets definition method across codebase (https://github.com/uw-ssec/llmaven/issues/89.
     return get_llmaven_secrets(env_file)
 
 

--- a/src/llmaven/deployment/validate.py
+++ b/src/llmaven/deployment/validate.py
@@ -6,7 +6,7 @@ This module provides the implementation for the 'llmaven validate' command.
 import re
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from ..infrastructure.config.loader import ConfigLoadError, load_config
 from ..infrastructure.config.schema import LLMavenConfig

--- a/src/llmaven/deployment/validate.py
+++ b/src/llmaven/deployment/validate.py
@@ -3,7 +3,6 @@
 This module provides the implementation for the 'llmaven validate' command.
 """
 
-import os
 import re
 import subprocess
 from pathlib import Path
@@ -11,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 
 from ..infrastructure.config.loader import ConfigLoadError, load_config
 from ..infrastructure.config.schema import LLMavenConfig
+from ..infrastructure.utils.secrets import get_llmaven_secrets
 
 
 class ValidationError(Exception):
@@ -146,51 +146,6 @@ def check_required_providers(subscription_id: str) -> Tuple[bool, str]:
         return False, "Provider check timed out"
     except Exception as e:
         return False, f"Failed to check providers: {e}"
-
-
-def get_llmaven_secrets(env_file_path: Optional[Path] = None) -> Dict[str, str]:
-    """Get all LLMAVEN_SECRETS_* environment variables.
-
-    Args:
-        env_file_path: Optional path to .env file to load secrets from
-
-    Returns:
-        Dictionary mapping secret names (kebab-case) to values
-    """
-    # Load from .env file if provided
-    if env_file_path is not None:
-        if not env_file_path.exists():
-            raise FileNotFoundError(f"Environment file not found: {env_file_path}")
-
-        try:
-            from dotenv import dotenv_values
-        except ImportError:
-            raise ImportError(
-                "python-dotenv is required to load .env files. "
-                "Install it with: pip install python-dotenv"
-            )
-
-        # Load the .env file
-        env_vars = dotenv_values(env_file_path)
-
-        # Only set LLMAVEN_SECRETS_* variables, and don't override existing ones
-        prefix = "LLMAVEN_SECRETS_"
-        for key, value in env_vars.items():
-            if key.startswith(prefix) and value is not None:
-                # Only set if not already in environment (env vars take precedence)
-                if key not in os.environ:
-                    os.environ[key] = value
-
-    secrets = {}
-    prefix = "LLMAVEN_SECRETS_"
-
-    for key, value in os.environ.items():
-        if key.startswith(prefix):
-            # Remove prefix and convert to kebab-case
-            secret_name = key[len(prefix) :].lower().replace("_", "-")
-            secrets[secret_name] = value
-
-    return secrets
 
 
 def check_secrets(

--- a/src/llmaven/infrastructure/utils/secrets.py
+++ b/src/llmaven/infrastructure/utils/secrets.py
@@ -235,9 +235,7 @@ def load_env_file(env_file_path: Optional[Path] = None) -> None:
                 loaded_count += 1
                 logger.info("Loaded secret from file: %s", key)
             else:
-                logger.info(
-                    "Skipping %s from file (already set in environment)", key
-                )
+                logger.info("Skipping %s from file (already set in environment)", key)
 
     logger.info("Loaded %d secrets from %s", loaded_count, env_file_path)
 

--- a/src/llmaven/infrastructure/utils/secrets.py
+++ b/src/llmaven/infrastructure/utils/secrets.py
@@ -7,6 +7,7 @@ This module provides utilities for secure secrets handling, including:
 - Secret name transformation
 """
 
+import logging
 import os
 import re
 import secrets
@@ -16,6 +17,8 @@ from typing import Dict, List, Optional, Set
 
 import pulumi
 from pulumi import Output
+
+logger = logging.getLogger(__name__)
 
 
 def generate_secure_password(
@@ -230,13 +233,13 @@ def load_env_file(env_file_path: Optional[Path] = None) -> None:
             if key not in os.environ:
                 os.environ[key] = value
                 loaded_count += 1
-                pulumi.log.info(f"✓ Loaded secret from file: {key}")
+                logger.info("Loaded secret from file: %s", key)
             else:
-                pulumi.log.info(
-                    f"⚠ Skipping {key} from file (already set in environment)"
+                logger.info(
+                    "Skipping %s from file (already set in environment)", key
                 )
 
-    pulumi.log.info(f"✓ Loaded {loaded_count} secrets from {env_file_path}")
+    logger.info("Loaded %d secrets from %s", loaded_count, env_file_path)
 
 
 def get_llmaven_secrets(env_file_path: Optional[Path] = None) -> Dict[str, str]:
@@ -272,7 +275,7 @@ def get_llmaven_secrets(env_file_path: Optional[Path] = None) -> Dict[str, str]:
             # Remove prefix and convert to kebab-case
             secret_name = key[len(prefix) :].lower().replace("_", "-")
             secrets[secret_name] = value
-            pulumi.log.info(f"✓ Found secret: {secret_name} (from {key})")
+            logger.info("Found secret: %s (from %s)", secret_name, key)
 
     return secrets
 

--- a/tests/infrastructure/test_cli_env_file_validation.py
+++ b/tests/infrastructure/test_cli_env_file_validation.py
@@ -144,3 +144,15 @@ class TestInfraDeployEnvFile:
         assert result.exit_code == 0
         kwargs = mock_deploy.call_args.kwargs
         assert kwargs["env_file_path"] is None
+
+
+class TestSecretsDedup:
+    """Issue #89: `deployment.validate.get_llmaven_secrets` must be the same
+    callable as `infrastructure.utils.secrets.get_llmaven_secrets`, not a
+    re-implementation that can drift."""
+
+    def test_validate_reexports_canonical_secrets_loader(self):
+        from llmaven.deployment import validate
+        from llmaven.infrastructure.utils import secrets as utils_secrets
+
+        assert validate.get_llmaven_secrets is utils_secrets.get_llmaven_secrets


### PR DESCRIPTION
There were two near-identical copies of get_llmaven_secrets:

  1. deployment/validate.py
  2. infrastructure/utils/secrets.py

The validate.py copy existed because the canonical one in infrastructure/utils/secrets.py used pulumi.log.info for diagnostic prints, which raises outside a Pulumi runtime — and 'llmaven infra validate' is run outside one. So validate.py inlined the logic to avoid that import path.

Fix: replace pulumi.log.info with stdlib logging in load_env_file and get_llmaven_secrets (the two helpers that can run outside a Pulumi runtime). The other pulumi.log call sites in secrets.py are inside auto-gen helpers that only ever run during pulumi up, so they stay on pulumi.log.

With that change the canonical helper is usable everywhere, so:
- Delete the duplicate get_llmaven_secrets from validate.py.
- Import it from infrastructure.utils.secrets at the top of validate.py. The CLI wrapper llmaven.cli._get_llmaven_secrets is unchanged (still wraps the canonical for test-mocking purposes).
- Drop the now-unused 'import os' in validate.py.

Test:
- New TestSecretsDedup test that asserts the two import paths resolve to the same callable, so they can't silently diverge again.