### PR TITLE
chore: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour in LLMaven
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug. Please fill in as much detail as possible so we can reproduce and fix it quickly.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behaviour.
+      placeholder: |
+        1. Run `llmaven ...`
+        2. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Include any error messages or stack traces.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Run the following and paste the output:
+        ```bash
+        pixi run -e llmaven python --version
+        pixi run -e llmaven llmaven --version
+        uname -a   # or "ver" on Windows
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or logs that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,8 @@ body:
     id: actual
     attributes:
       label: Actual behaviour
-      description: What actually happened? Include any error messages or stack traces.
+      description:
+        What actually happened? Include any error messages or stack traces.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,8 @@ body:
     id: problem
     attributes:
       label: Problem or motivation
-      description: What problem does this feature solve? What use case does it enable?
+      description:
+        What problem does this feature solve? What use case does it enable?
       placeholder: I'm trying to do X but currently have to Y instead...
     validations:
       required: true
@@ -20,7 +21,9 @@ body:
     id: solution
     attributes:
       label: Proposed solution
-      description: Describe the feature you'd like to see. Include any API or CLI design ideas.
+      description:
+        Describe the feature you'd like to see. Include any API or CLI design
+        ideas.
     validations:
       required: true
 
@@ -28,7 +31,8 @@ body:
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: Any alternative approaches or workarounds you've thought about?
+      description:
+        Any alternative approaches or workarounds you've thought about?
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Suggest a new feature or improvement for LLMaven
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping make LLMaven better! Please describe the feature you have in mind.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this feature solve? What use case does it enable?
+      placeholder: I'm trying to do X but currently have to Y instead...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature you'd like to see. Include any API or CLI design ideas.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches or workarounds you've thought about?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project does this touch?
+      multiple: true
+      options:
+        - CLI
+        - Infrastructure / Pulumi
+        - Agentic RAG
+        - API (FastAPI)
+        - Frontend (Streamlit)
+        - Docker / local stack
+        - Documentation
+        - CI / testing
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that would help — links, references, prior art.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- One or two sentences describing what this PR does and why. -->
+
+Closes #<!-- issue number -->
+
+## Changes
+
+<!-- Bullet list of what changed. Focus on the "what" and "why", not the "how". -->
+
+-
+-
+
+## Test plan
+
+<!-- How did you verify this works? Paste relevant test output or describe manual steps. -->
+
+- [ ] Existing tests pass (`pixi run -e llmaven pytest tests/`)
+- [ ] New tests added (if applicable)
+- [ ] `pre-commit run --all-files` passes
+
+## Notes for reviewer
+
+<!-- Anything that would help the reviewer: design decisions, trade-offs, known gaps. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to LLMaven
 
-Thank you for your interest in contributing to LLMaven! This project is developed
-by [UW SSEC](https://escience.washington.edu/software-engineering/ssec/) and
+Thank you for your interest in contributing to LLMaven! This project is
+developed by
+[UW SSEC](https://escience.washington.edu/software-engineering/ssec/) and
 welcomes contributions from the community.
 
 ## Table of Contents
@@ -31,21 +32,25 @@ welcomes contributions from the community.
 LLMaven uses [pixi](https://pixi.sh) to manage dependencies and environments.
 
 1. **Install pixi** if you haven't already:
+
    ```bash
    curl -fsSL https://pixi.sh/install.sh | bash
    ```
 
 2. **Install project dependencies:**
+
    ```bash
    pixi install
    ```
 
 3. **Activate the development environment:**
+
    ```bash
    pixi shell -e llmaven
    ```
 
 4. **Install pre-commit hooks:**
+
    ```bash
    pre-commit install
    ```
@@ -74,6 +79,7 @@ pixi run -e llmaven pytest tests/ --cov=llmaven
 ## Submitting a Pull Request
 
 1. **Create a feature branch** from `main`:
+
    ```bash
    git checkout -b fix/short-description
    # or
@@ -87,11 +93,13 @@ pixi run -e llmaven pytest tests/ --cov=llmaven
 4. **Run the full test suite** and ensure it passes.
 
 5. **Run pre-commit** to catch formatting and lint issues:
+
    ```bash
    pre-commit run --all-files
    ```
 
 6. **Push your branch** and open a pull request against `main`:
+
    ```bash
    git push origin your-branch-name
    ```
@@ -99,8 +107,8 @@ pixi run -e llmaven pytest tests/ --cov=llmaven
 7. **Fill in the PR template** — link the issue your PR closes with
    `Closes #<issue-number>` in the description.
 
-8. **Respond to review feedback** promptly. A maintainer will review your PR
-   and may request changes before merging.
+8. **Respond to review feedback** promptly. A maintainer will review your PR and
+   may request changes before merging.
 
 ### Commit message format
 
@@ -121,7 +129,7 @@ Common types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`.
 - **Type hints:** encouraged throughout; required for public API surfaces
 - **Dependencies:** runtime deps go in `pyproject.toml`; dev-only tools go in
   `pixi.toml`. Do not add a package to both unless there is a specific reason.
-- **Comments:** only when the *why* is non-obvious. Avoid restating what the
+- **Comments:** only when the _why_ is non-obvious. Avoid restating what the
   code already says.
 
 ## Reporting Issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing to LLMaven
+
+Thank you for your interest in contributing to LLMaven! This project is developed
+by [UW SSEC](https://escience.washington.edu/software-engineering/ssec/) and
+welcomes contributions from the community.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Development Setup](#development-setup)
+- [Running Tests](#running-tests)
+- [Submitting a Pull Request](#submitting-a-pull-request)
+- [Code Style](#code-style)
+- [Reporting Issues](#reporting-issues)
+
+## Getting Started
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your fork locally:
+   ```bash
+   git clone https://github.com/<your-username>/llmoxie.git
+   cd llmoxie
+   ```
+3. **Add the upstream remote** so you can pull in future changes:
+   ```bash
+   git remote add upstream https://github.com/uw-ssec/llmoxie.git
+   ```
+
+## Development Setup
+
+LLMaven uses [pixi](https://pixi.sh) to manage dependencies and environments.
+
+1. **Install pixi** if you haven't already:
+   ```bash
+   curl -fsSL https://pixi.sh/install.sh | bash
+   ```
+
+2. **Install project dependencies:**
+   ```bash
+   pixi install
+   ```
+
+3. **Activate the development environment:**
+   ```bash
+   pixi shell -e llmaven
+   ```
+
+4. **Install pre-commit hooks:**
+   ```bash
+   pre-commit install
+   ```
+
+5. **Verify your setup** by running the test suite (see below).
+
+## Running Tests
+
+```bash
+# All tests
+pixi run -e llmaven pytest tests/
+
+# Core tests only (fast)
+pixi run -e llmaven pytest tests/ --ignore=tests/agentic/ --ignore=tests/v1/
+
+# Agentic tests
+pixi run -e llmaven pytest tests/agentic/
+
+# API endpoint tests
+pixi run -e llmaven pytest tests/v1/
+
+# With coverage
+pixi run -e llmaven pytest tests/ --cov=llmaven
+```
+
+## Submitting a Pull Request
+
+1. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b fix/short-description
+   # or
+   git checkout -b feat/short-description
+   ```
+
+2. **Make your changes.** Keep commits focused — one logical change per commit.
+
+3. **Write or update tests** for any code you change.
+
+4. **Run the full test suite** and ensure it passes.
+
+5. **Run pre-commit** to catch formatting and lint issues:
+   ```bash
+   pre-commit run --all-files
+   ```
+
+6. **Push your branch** and open a pull request against `main`:
+   ```bash
+   git push origin your-branch-name
+   ```
+
+7. **Fill in the PR template** — link the issue your PR closes with
+   `Closes #<issue-number>` in the description.
+
+8. **Respond to review feedback** promptly. A maintainer will review your PR
+   and may request changes before merging.
+
+### Commit message format
+
+Follow the conventional commits style used in this repo:
+
+```
+<type>: short summary (#issue-number)
+
+Optional longer explanation.
+```
+
+Common types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`.
+
+## Code Style
+
+- **Formatter:** [ruff](https://docs.astral.sh/ruff/) (enforced via pre-commit)
+- **Linter:** ruff (enforced via pre-commit)
+- **Type hints:** encouraged throughout; required for public API surfaces
+- **Dependencies:** runtime deps go in `pyproject.toml`; dev-only tools go in
+  `pixi.toml`. Do not add a package to both unless there is a specific reason.
+- **Comments:** only when the *why* is non-obvious. Avoid restating what the
+  code already says.
+
+## Reporting Issues
+
+- Search [existing issues](https://github.com/uw-ssec/llmoxie/issues) before
+  opening a new one.
+- Use the appropriate issue template (bug report or feature request).
+- Provide enough detail to reproduce the problem or understand the request.
+
+## Code of Conduct
+
+This project follows the
+[Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating,
+you agree to uphold its standards. Please report unacceptable behaviour to the
+maintainers.


### PR DESCRIPTION
## Summary

Adds the community health files called out in #71 — a CONTRIBUTING.md guide, GitHub issue templates, and a PR template.

Closes #71

## Changes

- CONTRIBUTING.md with setup (pixi install, pre-commit), how to run tests, PR submission guide, commit message format, and code style rules
- .github/ISSUE_TEMPLATE/bug_report.yml with structured fields for environment, steps to reproduce, expected/actual behaviour
- .github/ISSUE_TEMPLATE/feature_request.yml with problem, proposed solution, area dropdown, and alternatives fields
- .github/pull_request_template.md with summary, changes, test plan checklist, and reviewer notes section

## Test plan

- [ ] No code changed — documentation and config files only
- [ ] Verified YAML templates are valid (no syntax errors)
- [ ] Issue templates will appear automatically on GitHub when opening a new issue

