### PR TITLE
feat: preserve comments in config updates via ruamel.yaml round-trip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "httpx>=0.27.0",
     "pydantic>=2.12.4",
     "pydantic-settings>=2.0.0",
+    "ruamel.yaml>=0.18.0",
     "typer>=0.21.0",
     "streamlit>=1.40.0",
     "langchain~=0.3.26",

--- a/src/llmaven/infrastructure/config/loader.py
+++ b/src/llmaven/infrastructure/config/loader.py
@@ -4,10 +4,11 @@ This module handles loading and parsing llmaven-config.yaml files.
 """
 
 from pathlib import Path
-from typing import Union
+from typing import Any, Union
 
 import yaml
 from pydantic import ValidationError
+from ruamel.yaml import YAML
 
 from .schema import LLMavenConfig
 
@@ -121,21 +122,37 @@ def save_config(config: LLMavenConfig, output_path: Union[str, Path]) -> None:
         raise ConfigLoadError(f"Failed to write configuration to {output_path}: {e}")
 
 
+def _coerce_yaml_value(value: Any) -> Any:
+    """Coerce an update value into the type written back to YAML.
+
+    The string ``"null"`` and ``None`` both map to a YAML ``null``. Booleans are
+    written as native YAML booleans (``true``/``false``). Everything else is
+    written as-is; ruamel.yaml adds quoting only when required.
+    """
+    if value is None or value == "null":
+        return None
+    return value
+
+
 def update_config_fields(
     config_path: Union[str, Path], updates: dict[str, str]
 ) -> None:
     """Update specific fields in YAML config while preserving formatting.
 
-    This function updates only the specified fields while preserving all comments,
-    blank lines, and formatting in the YAML file.
+    Uses a ruamel.yaml round-trip (load-modify-dump) so all comments, blank
+    lines, key ordering, and inline annotations are preserved. Field paths are
+    dotted and may be nested to any depth (e.g. ``azure.resource_group`` or
+    ``a.b.c``). Only existing fields are updated; unknown paths raise an error
+    rather than creating new keys, so user settings are never silently added to.
 
     Args:
         config_path: Path to llmaven-config.yaml file
-        updates: Dictionary mapping field paths to new values
+        updates: Dictionary mapping dotted field paths to new values
                  (e.g., {'azure.resource_group': 'rg-name'})
 
     Raises:
-        ConfigLoadError: If file operations fail
+        ConfigLoadError: If the file is missing, any field path does not exist,
+            or file operations fail.
 
     Example:
         update_config_fields('/path/to/llmaven-config.yaml', {
@@ -143,69 +160,60 @@ def update_config_fields(
             'project.pulumi_state_store': 'pulumistate'
         })
     """
-    import re
-
     config_path = Path(config_path)
     if not config_path.exists():
         raise ConfigLoadError(f"Configuration file not found: {config_path}")
 
+    yaml_rt = YAML()
+    yaml_rt.preserve_quotes = True
+    # Prevent ruamel from re-wrapping long scalars/comments onto new lines.
+    yaml_rt.width = 4096
+    # Render None as the explicit literal `null` (matching the template style)
+    # instead of an empty scalar, so existing `null` lines round-trip unchanged.
+    yaml_rt.representer.add_representer(
+        type(None),
+        lambda representer, _: representer.represent_scalar(
+            "tag:yaml.org,2002:null", "null"
+        ),
+    )
+
     try:
         with open(config_path, "r") as f:
-            content = f.read()
+            data = yaml_rt.load(f)
     except Exception as e:
         raise ConfigLoadError(f"Failed to read configuration file {config_path}: {e}")
 
-    lines = content.split("\n")
-    result_lines = []
-    applied_updates = set()
-    current_section = None
+    if data is None:
+        raise ConfigLoadError(
+            f"Configuration file is empty: {config_path}\n"
+            f"Cannot update fields in an empty configuration."
+        )
 
-    for line in lines:
-        section_match = re.match(r"^([a-z_]+):\s*(?:#.*)?$", line)
-        if section_match:
-            current_section = section_match.group(1)
-            result_lines.append(line)
+    not_found = []
+    for path, new_value in updates.items():
+        keys = path.split(".")
+        node = data
+        # Walk to the parent mapping of the leaf key.
+        for key in keys[:-1]:
+            if not isinstance(node, dict) or key not in node:
+                node = None
+                break
+            node = node[key]
+
+        leaf = keys[-1]
+        if not isinstance(node, dict) or leaf not in node:
+            not_found.append(path)
             continue
 
-        field_match = (
-            re.match(r"^(\s+)([a-z_]+):\s*(.*)$", line) if current_section else None
-        )
-        if field_match:
-            indent, field_name, rest = field_match.groups()
-            full_path = f"{current_section}.{field_name}"
+        node[leaf] = _coerce_yaml_value(new_value)
 
-            if full_path in updates:
-                new_value = updates[full_path]
-                applied_updates.add(full_path)
-                comment = (
-                    comment_match.group(1)
-                    if (comment_match := re.search(r"(\s+#.*)$", rest))
-                    else ""
-                )
-
-                formatted_value = (
-                    "null"
-                    if new_value in [None, "null"]
-                    else str(new_value).lower()
-                    if isinstance(new_value, bool)
-                    else f'"{new_value}"'
-                    if isinstance(new_value, str)
-                    and (" " in new_value or ":" in new_value)
-                    else str(new_value)
-                )
-                result_lines.append(f"{indent}{field_name}: {formatted_value}{comment}")
-                continue
-
-        result_lines.append(line)
-
-    unapplied_updates = set(updates.keys()) - applied_updates
-    if unapplied_updates:
+    if not_found:
         raise ConfigLoadError(
-            f"Configuration fields not found: {', '.join(sorted(unapplied_updates))}"
+            f"Configuration fields not found: {', '.join(sorted(not_found))}"
         )
 
     try:
         with open(config_path, "w") as f:
-            f.write("\n".join(result_lines))
+            yaml_rt.dump(data, f)
     except Exception as e:
         raise ConfigLoadError(f"Failed to write configuration file {config_path}: {e}")

--- a/tests/infrastructure/test_config_loader.py
+++ b/tests/infrastructure/test_config_loader.py
@@ -219,4 +219,6 @@ def test_untouched_null_fields_stay_null(tmp_path):
 
     result = config_path.read_text()
     # The untouched null line is rendered as explicit `null`, not blank.
-    assert "pulumi_state_store: null  # Azure Storage account (auto-generated)" in result
+    assert (
+        "pulumi_state_store: null  # Azure Storage account (auto-generated)" in result
+    )

--- a/tests/infrastructure/test_config_loader.py
+++ b/tests/infrastructure/test_config_loader.py
@@ -1,0 +1,222 @@
+"""Tests for the configuration loader, focused on update_config_fields().
+
+These tests verify the ruamel.yaml round-trip behavior introduced for
+https://github.com/uw-ssec/llmaven/issues/95: programmatic field updates must
+preserve comments, blank lines, key ordering, and inline annotations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llmaven.infrastructure.config.loader import (
+    ConfigLoadError,
+    update_config_fields,
+)
+
+
+# Mirrors the structure and comment style of the real generated template
+# (get_config_template_yaml): top-level sections, inline comments, `null`
+# placeholders that deployment fills in, and list values.
+SAMPLE_CONFIG = """\
+# llmaven-config.yaml
+# Top-of-file banner comment
+
+# Project Information
+project:
+  name: llmaven
+  environment: dev  # dev, staging, prod
+  location: eastus  # Azure region
+  pulumi_state_store: null  # Azure Storage account (auto-generated)
+
+# Azure Subscription
+azure:
+  subscription_id: ""  # required
+  resource_group: null  # Resource group name (auto-generated)
+
+# Database Configuration
+database:
+  sku_name: B_Standard_B1ms  # tier
+  databases:
+    - llmaven
+    - mlflow_db
+
+# Deeply nested section for path tests
+outer:
+  inner:
+    leaf: original  # keep this comment
+"""
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    config_path = tmp_path / "llmaven-config.yaml"
+    config_path.write_text(content)
+    return config_path
+
+
+def test_updates_nested_field_and_preserves_inline_comment(tmp_path):
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+
+    update_config_fields(
+        config_path,
+        {"azure.resource_group": "rg-llmaven-westus"},
+    )
+
+    result = config_path.read_text()
+    # Value updated
+    assert "resource_group: rg-llmaven-westus" in result
+    # Inline comment preserved
+    assert "# Resource group name (auto-generated)" in result
+    # null replaced, not duplicated
+    assert "resource_group: null" not in result
+
+
+def test_updates_null_field_to_value(tmp_path):
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+
+    update_config_fields(
+        config_path,
+        {"project.pulumi_state_store": "pulumistate01"},
+    )
+
+    result = config_path.read_text()
+    assert "pulumi_state_store: pulumistate01" in result
+    assert "# Azure Storage account (auto-generated)" in result
+
+
+def test_preserves_unrelated_comments_and_blank_lines(tmp_path):
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+
+    update_config_fields(
+        config_path,
+        {"azure.resource_group": "rg-x"},
+    )
+
+    result = config_path.read_text()
+    # Banner and section comments untouched
+    assert "# Top-of-file banner comment" in result
+    assert "# Project Information" in result
+    assert "# Azure Subscription" in result
+    # Untouched fields remain
+    assert "name: llmaven" in result
+    assert "environment: dev  # dev, staging, prod" in result
+
+
+def test_updates_deeply_nested_path(tmp_path):
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+
+    update_config_fields(config_path, {"outer.inner.leaf": "changed"})
+
+    result = config_path.read_text()
+    # Value updated and the inline comment is preserved (ruamel keeps the
+    # comment at its original column, so spacing may differ — assert separately).
+    assert "leaf: changed" in result
+    assert "# keep this comment" in result
+
+
+def test_applies_multiple_updates_at_once(tmp_path):
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+
+    update_config_fields(
+        config_path,
+        {
+            "azure.resource_group": "rg-multi",
+            "project.pulumi_state_store": "store-multi",
+        },
+    )
+
+    result = config_path.read_text()
+    assert "resource_group: rg-multi" in result
+    assert "pulumi_state_store: store-multi" in result
+
+
+def test_string_null_maps_to_yaml_null(tmp_path):
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+
+    # Start from a value, then set it back to null via the "null" string.
+    update_config_fields(config_path, {"azure.resource_group": "temp"})
+    update_config_fields(config_path, {"azure.resource_group": "null"})
+
+    result = config_path.read_text()
+    assert "resource_group: null" in result
+
+
+def test_missing_field_raises_and_does_not_write(tmp_path):
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+    before = config_path.read_text()
+
+    with pytest.raises(ConfigLoadError) as exc:
+        update_config_fields(
+            config_path,
+            {
+                "azure.resource_group": "rg-ok",
+                "azure.does_not_exist": "nope",
+            },
+        )
+
+    # The missing path is reported.
+    assert "azure.does_not_exist" in str(exc.value)
+    # The file is left untouched (atomic: no partial write on error).
+    assert config_path.read_text() == before
+
+
+def test_missing_intermediate_key_raises(tmp_path):
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+
+    with pytest.raises(ConfigLoadError) as exc:
+        update_config_fields(config_path, {"nonexistent.child": "x"})
+
+    assert "nonexistent.child" in str(exc.value)
+
+
+def test_missing_file_raises(tmp_path):
+    with pytest.raises(ConfigLoadError) as exc:
+        update_config_fields(tmp_path / "nope.yaml", {"a.b": "c"})
+
+    assert "not found" in str(exc.value)
+
+
+def test_empty_file_raises(tmp_path):
+    config_path = _write(tmp_path, "")
+
+    with pytest.raises(ConfigLoadError) as exc:
+        update_config_fields(config_path, {"a.b": "c"})
+
+    assert "empty" in str(exc.value).lower()
+
+
+def test_deploy_caller_scenario_preserves_comments_and_lists(tmp_path):
+    """Mirror the real deploy.py caller: write both backend fields at once."""
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+
+    update_config_fields(
+        config_path,
+        {
+            "azure.resource_group": "rg-llmaven-dev",
+            "project.pulumi_state_store": "llmavenstate",
+        },
+    )
+
+    result = config_path.read_text()
+    assert "resource_group: rg-llmaven-dev" in result
+    assert "pulumi_state_store: llmavenstate" in result
+    # Representative inline comments survive.
+    assert "# Azure region" in result
+    assert "dev, staging, prod" in result
+    # List values are preserved verbatim.
+    assert "- llmaven" in result
+    assert "- mlflow_db" in result
+
+
+def test_untouched_null_fields_stay_null(tmp_path):
+    """Updating one field must not rewrite other `null` lines to empty scalars."""
+    config_path = _write(tmp_path, SAMPLE_CONFIG)
+
+    # Only update resource_group; pulumi_state_store stays null.
+    update_config_fields(config_path, {"azure.resource_group": "rg-x"})
+
+    result = config_path.read_text()
+    # The untouched null line is rendered as explicit `null`, not blank.
+    assert "pulumi_state_store: null  # Azure Storage account (auto-generated)" in result


### PR DESCRIPTION
## Summary

Replaces the regex-based `update_config_fields` with a ruamel.yaml round-trip so programmatic config updates preserve comments, blank lines, key ordering, and inline annotations.

Closes #95

## Problem

`update_config_fields` (in `infrastructure/config/loader.py`) edited the YAML line-by-line with regexes. It only matched single-level `section.field` paths and was fragile against any formatting it did not anticipate. The issue asked for a `ruamel.yaml` round-trip that preserves comments and formatting.

## Changes

- Rewrite `update_config_fields` to load-modify-dump with `ruamel.yaml`.
- Support dotted field paths of arbitrary depth (the only caller, `deploy.py`, passes two-level paths like `azure.resource_group` and `project.pulumi_state_store`).
- Register a None representer so `None`/`"null"` render as the explicit literal `null`, matching the template style. Without this, ruamel rewrites existing `null` lines to empty scalars, producing collateral diffs on untouched lines.
- Cap line width so long scalars/comments are not re-wrapped.
- Preserve the existing contract: unknown field paths raise `ConfigLoadError` and the file is left untouched (no partial writes).
- Add `ruamel.yaml>=0.18.0` to `pyproject.toml` dependencies — it is imported by the installable package, so pip users need it (consistent with the runtime-deps-in-pyproject convention from #118).

## Testing

New `tests/infrastructure/test_config_loader.py` (12 tests, all passing) covering:

- Inline comment preservation on nested-field updates
- `null` → value and `"null"` → `null` handling
- Untouched `null` lines stay `null` (no collateral diffs)
- Deeply nested paths (`a.b.c`)
- List value preservation
- Multi-field updates in one call
- Error paths: missing file, missing field (atomic — no write), missing intermediate key, empty file

Verified with a unified diff that a real two-field update (mirroring the `deploy.py` caller) changes **only** the two target lines and leaves the rest byte-identical.

## Out of scope

The issue also suggested optionally relocating `save_config`/`update_config_fields` out of `loader.py`. I kept them in place to keep this change focused and avoid touching the `deploy.py` import path; happy to do that as a follow-up if desired.