### PR TITLE
feat: include Pulumi state store in monthly cost estimate

### DIFF
--- a/src/llmaven/deployment/validate.py
+++ b/src/llmaven/deployment/validate.py
@@ -347,6 +347,14 @@ def check_config_for_hardcoded_secrets(config_path: Path) -> Tuple[bool, List[st
     return not has_hardcoded_secrets, messages
 
 
+# Pulumi state store: a Standard LRS storage account that holds the Pulumi
+# state blobs. State files are small and transaction volume is low, so the cost
+# is modest, but every Azure deployment provisions one (auto-created when
+# project.pulumi_state_store is not supplied), so it is always included.
+STATE_STORE_MIN_COST = 1.0
+STATE_STORE_MAX_COST = 3.0
+
+
 def estimate_monthly_cost(config: LLMavenConfig) -> Tuple[float, float]:
     """Estimate monthly Azure cost based on configuration.
 
@@ -381,6 +389,10 @@ def estimate_monthly_cost(config: LLMavenConfig) -> Tuple[float, float]:
     # Blob Storage (rough estimate)
     min_cost += 2.0
     max_cost += 5.0
+
+    # Pulumi state store (separate storage account used as the Pulumi backend)
+    min_cost += STATE_STORE_MIN_COST
+    max_cost += STATE_STORE_MAX_COST
 
     # Container Apps (based on CPU/memory allocation)
     if config.mlflow and config.mlflow.enabled:

--- a/tests/infrastructure/test_cost_estimate.py
+++ b/tests/infrastructure/test_cost_estimate.py
@@ -1,0 +1,80 @@
+"""Tests for estimate_monthly_cost(), focused on the Pulumi state store line.
+
+Covers https://github.com/uw-ssec/llmaven/issues/84: the monthly estimate must
+account for the Pulumi state store (a separate Azure Storage account used as the
+deployment backend).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmaven.deployment.validate import (
+    STATE_STORE_MAX_COST,
+    STATE_STORE_MIN_COST,
+    estimate_monthly_cost,
+)
+from llmaven.infrastructure.config.schema import (
+    BackupJobConfig,
+    DatabaseConfig,
+    LiteLLMConfig,
+    LLMavenAPIConfig,
+    LLMavenConfig,
+    MLflowConfig,
+    MonitoringConfig,
+)
+
+
+def _minimal_config() -> LLMavenConfig:
+    """A config with every optional/container service disabled.
+
+    With container apps and monitoring off, the estimate is fully determined by
+    the database tier, database storage, blob storage, and the state store —
+    which makes the arithmetic exact and independent of unrelated defaults.
+    """
+    return LLMavenConfig(
+        database=DatabaseConfig(sku_name="B_Standard_B1ms", storage_size_gb=32),
+        mlflow=MLflowConfig(enabled=False),
+        litellm=LiteLLMConfig(enabled=False),
+        llmaven_api=LLMavenAPIConfig(enabled=False),
+        monitoring=MonitoringConfig(enable_application_insights=False),
+        # backup_job.database is required; enabled defaults False so the
+        # cross-field validation against database.databases is skipped.
+        backup_job=BackupJobConfig(database="llmaven"),
+    )
+
+
+def test_state_store_constants_are_sane():
+    assert STATE_STORE_MIN_COST > 0
+    assert STATE_STORE_MAX_COST >= STATE_STORE_MIN_COST
+
+
+def test_state_store_is_included_in_estimate():
+    config = _minimal_config()
+
+    min_cost, max_cost = estimate_monthly_cost(config)
+
+    # Burstable DB (13/20) + storage 32 * 0.115 (min only) + blob (2/5)
+    # + state store. Everything else is disabled.
+    expected_without_state_store_min = 13.0 + (32 * 0.115) + 2.0
+    expected_without_state_store_max = 20.0 + 5.0
+
+    assert min_cost == pytest.approx(
+        expected_without_state_store_min + STATE_STORE_MIN_COST
+    )
+    assert max_cost == pytest.approx(
+        expected_without_state_store_max + STATE_STORE_MAX_COST
+    )
+
+
+def test_enabling_a_container_app_still_adds_its_cost():
+    """Guard against regressions in the existing container-app math."""
+    base_min, base_max = estimate_monthly_cost(_minimal_config())
+
+    config = _minimal_config()
+    config.mlflow = MLflowConfig(enabled=True, cpu=0.5)
+    with_mlflow_min, with_mlflow_max = estimate_monthly_cost(config)
+
+    # 0.5 vCPU * 15/30 per the existing rough rates.
+    assert with_mlflow_min == pytest.approx(base_min + 0.5 * 15.0)
+    assert with_mlflow_max == pytest.approx(base_max + 0.5 * 30.0)


### PR DESCRIPTION
## Summary

Adds the Pulumi state store to `estimate_monthly_cost` so the monthly estimate reflects every resource a deployment provisions.

Closes #84

## Problem

`estimate_monthly_cost` (in `deployment/validate.py`) summed PostgreSQL, database storage, blob storage, container apps, and monitoring — but omitted the Pulumi state store. That store is a separate Standard LRS storage account used as the Pulumi backend, auto-created during deployment when `project.pulumi_state_store` is not supplied, so it is always part of a deployment's cost.

## Changes

- Add `STATE_STORE_MIN_COST` / `STATE_STORE_MAX_COST` module constants (`1.0` / `3.0`). State files are small and transaction volume is low, so this is a deliberately conservative rough estimate, consistent with the other rough line items in this function.
- Add the state store unconditionally to both the min and max totals.

The existing `llmaven infra validate` cost-estimation display consumes the returned tuple unchanged, so the new line flows through with no other edits.

## Testing

New `tests/infrastructure/test_cost_estimate.py` (3 tests, all passing):

- `test_state_store_is_included_in_estimate` builds a config with all container apps and monitoring disabled — making the arithmetic fully determined — and asserts the exact min/max, tying the delta to the state-store constants.
- `test_enabling_a_container_app_still_adds_its_cost` guards the existing container-app math against regressions.
- `test_state_store_constants_are_sane` checks the constants are positive and ordered.

## Note on the estimate values

`1.0`–`3.0` is a rough figure in the same spirit as the surrounding estimates (all commented "rough estimate"). Happy to adjust if maintainers have a preferred figure or want it scaled by region/replication.