### PR TITLE
fix: give BackupJobConfig.database a default so infra init works

### DIFF
--- a/src/llmaven/infrastructure/config/schema.py
+++ b/src/llmaven/infrastructure/config/schema.py
@@ -301,6 +301,7 @@ class BackupJobConfig(BaseModel):
         default=1800, description="Max job runtime in seconds", ge=60
     )
     database: str = Field(
+        default="llmaven",
         description="Name of the PostgreSQL database to back up (must match one of database.databases)",
     )
     connection_string_env: str = Field(

--- a/tests/infrastructure/test_schema_defaults.py
+++ b/tests/infrastructure/test_schema_defaults.py
@@ -1,0 +1,67 @@
+"""Regression tests for default construction of LLMavenConfig.
+
+Covers https://github.com/uw-ssec/llmaven/issues/140: LLMavenConfig used
+``default_factory=BackupJobConfig`` while ``BackupJobConfig.database`` had no
+default, so any LLMavenConfig() without an explicit backup_job raised — which
+broke ``llmaven infra init`` (via get_config_template_yaml).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmaven.infrastructure.config.defaults import (
+    generate_default_config,
+    get_config_template_yaml,
+)
+from llmaven.infrastructure.config.schema import (
+    BackupJobConfig,
+    DatabaseConfig,
+    LLMavenConfig,
+)
+
+
+def test_backup_job_config_constructs_with_no_args():
+    job = BackupJobConfig()
+    assert job.enabled is False
+    assert job.database == "llmaven"
+
+
+def test_llmaven_config_constructs_with_defaults():
+    config = LLMavenConfig()
+    # The default backup job is present and disabled.
+    assert config.backup_job.enabled is False
+    assert config.backup_job.database == "llmaven"
+
+
+def test_default_backup_database_is_a_valid_default_database():
+    """If backups are enabled without changing the database, validation passes."""
+    assert BackupJobConfig().database in DatabaseConfig().databases
+
+
+@pytest.mark.parametrize("environment", ["dev", "staging", "prod"])
+def test_generate_default_config_succeeds(environment):
+    config = generate_default_config(environment)
+    assert config.backup_job.database == "llmaven"
+
+
+@pytest.mark.parametrize("environment", ["dev", "staging", "prod"])
+def test_get_config_template_yaml_succeeds(environment):
+    # This is the `llmaven infra init` code path; it must not raise.
+    template = get_config_template_yaml(environment)
+    assert isinstance(template, str)
+    assert "project:" in template
+
+
+def test_enabling_backup_with_default_database_passes_validation():
+    config = LLMavenConfig(backup_job=BackupJobConfig(enabled=True))
+    assert config.backup_job.enabled is True
+
+
+def test_validator_still_rejects_enabled_with_unknown_database():
+    """The fix must not weaken the existing cross-field validation."""
+    with pytest.raises(Exception) as exc:
+        LLMavenConfig(
+            backup_job=BackupJobConfig(enabled=True, database="not_a_real_db")
+        )
+    assert "not_a_real_db" in str(exc.value)


### PR DESCRIPTION
## Summary

Fixes a crash in `llmaven infra init` (and any `LLMavenConfig()` construction without an explicit `backup_job`).

Closes #140

## Root cause

`LLMavenConfig.backup_job` is declared with `default_factory=BackupJobConfig`, but `BackupJobConfig.database` was a required field with no default. Producing the default backup job called `BackupJobConfig()` with no args, which raised:

```
ValidationError: 1 validation error for BackupJobConfig
database
  Field required [type=missing, input_value={}, input_type=dict]
```

So every `LLMavenConfig()` without an explicit `backup_job` failed. That broke:
- `get_config_template_yaml()` — the `llmaven infra init` code path
- `generate_default_config()`
- `load_config()` on any YAML without a `backup_job` section

## Fix

Give `BackupJobConfig.database` a default of `"llmaven"`:
- It is the primary application database (matches `admin_login: llmaven_admin`).
- It is a member of the default `database.databases` list (`["llmaven", "mlflow_db", "litellm_db"]`), so the existing `model_post_init` cross-check still passes if backups are enabled without changing the database.
- The backup job is disabled by default (`enabled: false`), so the value only takes effect once a user turns backups on.

## Testing

New `tests/infrastructure/test_schema_defaults.py` (11 tests, all passing):
- `BackupJobConfig()` and `LLMavenConfig()` construct with defaults
- the default backup database is a member of the default databases list
- `generate_default_config` and `get_config_template_yaml` succeed across dev/staging/prod
- enabling backups with the default database passes validation
- **regression guard**: enabling backups with an unknown database still raises (the fix does not weaken the cross-field validation)

Verified before/after: on `main` all three entry points raise `ValidationError`; with this change they succeed and a generated template round-trips back through `load_config`.