### PR TITLE
fix(agentic): pass LLM overrides through factory instead of mutating global config

### DIFF
--- a/src/llmaven/agentic/agent/rag_agent.py
+++ b/src/llmaven/agentic/agent/rag_agent.py
@@ -78,17 +78,17 @@ class RAGAgent:
             collection_name=self.collection_name
         )
 
-        # Override config if provider/model specified
-        if llm_provider:
-            config.llm_provider = llm_provider
-        if llm_model:
-            config.llm_model = llm_model
+        # Resolve effective provider/model locally; RAGAgent is constructed
+        # per-request and writing back to the global singleton would leak the
+        # override to subsequent requests that didn't ask for it.
+        effective_provider = llm_provider or config.llm_provider
+        effective_model = llm_model or config.llm_model
 
         # Create LLM model using provider factory
         try:
-            llm = create_llm_model()
+            llm = create_llm_model(provider=llm_provider, model=llm_model)
             logger.info(
-                f"Initializing RAG Agent with provider: {config.llm_provider}, model: {config.llm_model}"
+                f"Initializing RAG Agent with provider: {effective_provider}, model: {effective_model}"
             )
 
             # Create the agent with structured output
@@ -104,7 +104,7 @@ class RAGAgent:
 
             logger.info(
                 f"RAG Agent initialized for collection '{self.collection_name}' "
-                f"with provider '{config.llm_provider}' and model '{config.llm_model}'"
+                f"with provider '{effective_provider}' and model '{effective_model}'"
             )
 
         except ProviderConfigurationError:

--- a/src/llmaven/agentic/providers/factory.py
+++ b/src/llmaven/agentic/providers/factory.py
@@ -16,8 +16,15 @@ from llmaven.agentic.exceptions import ProviderConfigurationError
 from llmaven.agentic.settings import config
 
 
-def create_llm_model() -> OpenAIChatModel:
+def create_llm_model(
+    provider: str | None = None,
+    model: str | None = None,
+) -> OpenAIChatModel:
     """Create an LLM model based on the configured provider.
+
+    Args:
+        provider: Optional provider override. Defaults to ``config.llm_provider``.
+        model: Optional model override. Defaults to ``config.llm_model``.
 
     Returns:
         OpenAIChatModel: The configured LLM model instance.
@@ -25,23 +32,24 @@ def create_llm_model() -> OpenAIChatModel:
     Raises:
         ProviderConfigurationError: If the provider is unsupported or configuration is invalid.
     """
-    provider = config.llm_provider.lower()
+    resolved_provider = (provider or config.llm_provider).lower()
+    resolved_model = model or config.llm_model
 
-    if provider == "openai":
-        return _create_openai_model()
-    elif provider == "ollama":
-        return _create_ollama_model()
-    elif provider == "litellm":
-        return _create_litellm_model()
-    elif provider == "azure":
-        return _create_azure_model()
-    elif provider == "huggingface":
+    if resolved_provider == "openai":
+        return _create_openai_model(resolved_model)
+    elif resolved_provider == "ollama":
+        return _create_ollama_model(resolved_model)
+    elif resolved_provider == "litellm":
+        return _create_litellm_model(resolved_model)
+    elif resolved_provider == "azure":
+        return _create_azure_model(resolved_model)
+    elif resolved_provider == "huggingface":
         return _create_huggingface_model()
     else:
-        raise ProviderConfigurationError(f"Unsupported provider: {provider}")
+        raise ProviderConfigurationError(f"Unsupported provider: {resolved_provider}")
 
 
-def _create_openai_model() -> OpenAIChatModel:
+def _create_openai_model(model: str) -> OpenAIChatModel:
     """Create OpenAI model using default provider.
 
     Returns:
@@ -57,10 +65,10 @@ def _create_openai_model() -> OpenAIChatModel:
     )
 
     provider = OpenAIProvider(http_client=http_client)
-    return OpenAIChatModel(config.llm_model, provider=provider)
+    return OpenAIChatModel(model, provider=provider)
 
 
-def _create_ollama_model() -> OpenAIChatModel:
+def _create_ollama_model(model: str) -> OpenAIChatModel:
     """Create Ollama model using OpenAI-compatible endpoint.
 
     Ollama provides an OpenAI-compatible API at /v1 endpoint.
@@ -83,10 +91,10 @@ def _create_ollama_model() -> OpenAIChatModel:
     provider = OllamaProvider(
         base_url=base_url, api_key=api_key, http_client=http_client
     )
-    return OpenAIChatModel(config.llm_model, provider=provider)
+    return OpenAIChatModel(model, provider=provider)
 
 
-def _create_litellm_model() -> OpenAIChatModel:
+def _create_litellm_model(model: str) -> OpenAIChatModel:
     """Create LiteLLM model for unified provider access.
 
     LiteLLM provides a unified interface to 100+ LLM providers through
@@ -109,7 +117,7 @@ def _create_litellm_model() -> OpenAIChatModel:
         )
 
     # Construct model name with prefix if specified
-    model_name = f"{config.litellm_model_prefix}{config.llm_model}"
+    model_name = f"{config.litellm_model_prefix}{model}"
 
     # Create HTTP client with timeout configuration
     import httpx
@@ -127,7 +135,7 @@ def _create_litellm_model() -> OpenAIChatModel:
     return OpenAIChatModel(model_name, provider=provider)
 
 
-def _create_azure_model() -> OpenAIChatModel:
+def _create_azure_model(model: str) -> OpenAIChatModel:
     """Create Azure AI Foundry model.
 
     Azure OpenAI Service provides OpenAI models through Azure's infrastructure
@@ -155,7 +163,7 @@ def _create_azure_model() -> OpenAIChatModel:
         )
 
     # Use deployment name if specified, otherwise use model name
-    deployment = config.azure_deployment_name or config.llm_model
+    deployment = config.azure_deployment_name or model
 
     # Construct Azure OpenAI base URL
     # Azure uses: https://{resource}.openai.azure.com/openai/deployments/{deployment}/

--- a/tests/agentic/test_providers.py
+++ b/tests/agentic/test_providers.py
@@ -111,13 +111,12 @@ class TestOpenAIProvider:
         """Test creating OpenAI model directly."""
         from unittest.mock import ANY
 
-        with patch("llmaven.agentic.providers.factory.config") as mock_config:
-            mock_config.llm_model = "gpt-4o-mini"
+        with patch("llmaven.agentic.providers.factory.config"):
             mock_provider_instance = MagicMock()
             mock_provider_class.return_value = mock_provider_instance
             mock_model_class.return_value = MagicMock()
 
-            result = _create_openai_model()
+            result = _create_openai_model("gpt-4o-mini")
 
             mock_provider_class.assert_called_once_with(http_client=ANY)
             mock_model_class.assert_called_once_with(
@@ -134,13 +133,12 @@ class TestOllamaProvider:
     @patch.dict("os.environ", {}, clear=True)
     def test_create_ollama_model_defaults(self, mock_provider_class, mock_model_class):
         """Test creating Ollama model with default settings."""
-        with patch("llmaven.agentic.providers.factory.config") as mock_config:
-            mock_config.llm_model = "llama2"
+        with patch("llmaven.agentic.providers.factory.config"):
             mock_provider_instance = MagicMock()
             mock_provider_class.return_value = mock_provider_instance
             mock_model_class.return_value = MagicMock()
 
-            result = _create_ollama_model()
+            result = _create_ollama_model("llama2")
 
             from unittest.mock import ANY
 
@@ -165,13 +163,12 @@ class TestOllamaProvider:
         self, mock_provider_class, mock_model_class
     ):
         """Test creating Ollama model with custom environment variables."""
-        with patch("llmaven.agentic.providers.factory.config") as mock_config:
-            mock_config.llm_model = "llama2"
+        with patch("llmaven.agentic.providers.factory.config"):
             mock_provider_instance = MagicMock()
             mock_provider_class.return_value = mock_provider_instance
             mock_model_class.return_value = MagicMock()
 
-            result = _create_ollama_model()
+            result = _create_ollama_model("llama2")
 
             from unittest.mock import ANY
 
@@ -198,12 +195,11 @@ class TestLiteLLMProvider:
             mock_config.litellm_api_base = "http://localhost:4000"
             mock_config.litellm_api_key = "test-key"
             mock_config.litellm_model_prefix = "openai/"
-            mock_config.llm_model = "gpt-4o-mini"
             mock_provider_instance = MagicMock()
             mock_provider_class.return_value = mock_provider_instance
             mock_model_class.return_value = MagicMock()
 
-            result = _create_litellm_model()
+            result = _create_litellm_model("gpt-4o-mini")
 
             from unittest.mock import ANY
 
@@ -228,12 +224,11 @@ class TestLiteLLMProvider:
             mock_config.litellm_api_base = "http://localhost:4000"
             mock_config.litellm_api_key = None
             mock_config.litellm_model_prefix = ""
-            mock_config.llm_model = "gpt-4o-mini"
             mock_provider_instance = MagicMock()
             mock_provider_class.return_value = mock_provider_instance
             mock_model_class.return_value = MagicMock()
 
-            result = _create_litellm_model()
+            result = _create_litellm_model("gpt-4o-mini")
 
             from unittest.mock import ANY
 
@@ -257,7 +252,7 @@ class TestLiteLLMProvider:
                 ProviderConfigurationError,
                 match="AGENTIC_LITELLM_API_BASE is required for LiteLLM provider",
             ):
-                _create_litellm_model()
+                _create_litellm_model("gpt-4o-mini")
 
 
 class TestAzureProvider:
@@ -274,7 +269,6 @@ class TestAzureProvider:
             mock_config.azure_endpoint = "https://myresource.openai.azure.com"
             mock_config.azure_api_key = "test-key"
             mock_config.azure_deployment_name = "gpt-4o-deployment"
-            mock_config.llm_model = "gpt-4o"
             mock_config.azure_api_version = "2024-10-21"
             mock_http_client_instance = MagicMock()
             mock_http_client_class.return_value = mock_http_client_instance
@@ -282,7 +276,7 @@ class TestAzureProvider:
             mock_provider_class.return_value = mock_provider_instance
             mock_model_class.return_value = MagicMock()
 
-            result = _create_azure_model()
+            result = _create_azure_model("gpt-4o")
 
             mock_http_client_class.assert_called_once()
             http_call_kwargs = mock_http_client_class.call_args[1]
@@ -315,7 +309,6 @@ class TestAzureProvider:
             mock_config.azure_endpoint = "https://myresource.openai.azure.com"
             mock_config.azure_api_key = "test-key"
             mock_config.azure_deployment_name = None
-            mock_config.llm_model = "gpt-4o"
             mock_config.azure_api_version = "2024-10-21"
             mock_http_client_instance = MagicMock()
             mock_http_client_class.return_value = mock_http_client_instance
@@ -323,7 +316,7 @@ class TestAzureProvider:
             mock_provider_class.return_value = mock_provider_instance
             mock_model_class.return_value = MagicMock()
 
-            result = _create_azure_model()
+            result = _create_azure_model("gpt-4o")
 
             mock_provider_class.assert_called_once()
             provider_call_kwargs = mock_provider_class.call_args[1]
@@ -348,7 +341,7 @@ class TestAzureProvider:
                 ProviderConfigurationError,
                 match="AGENTIC_AZURE_ENDPOINT is required for Azure provider",
             ):
-                _create_azure_model()
+                _create_azure_model("gpt-4o")
 
     def test_create_azure_model_missing_api_key(self):
         """Test that missing Azure API key raises error."""
@@ -360,7 +353,7 @@ class TestAzureProvider:
                 ProviderConfigurationError,
                 match="AGENTIC_AZURE_API_KEY is required for Azure provider",
             ):
-                _create_azure_model()
+                _create_azure_model("gpt-4o")
 
 
 class TestHuggingFaceProvider:

--- a/tests/agentic/test_rag_agent.py
+++ b/tests/agentic/test_rag_agent.py
@@ -4,6 +4,8 @@ This module tests the RAGAgent functionality including initialization,
 tool registration, agent execution, and error handling.
 """
 
+import asyncio
+
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
 
@@ -12,6 +14,7 @@ from llmaven.agentic.agent.models import RAGResponse, Citation
 from llmaven.agentic.search.hybrid_searcher import HybridSearcher
 from llmaven.agentic.search.models import SearchResult
 from llmaven.agentic.exceptions import AgenticRAGError
+from llmaven.agentic.settings import config as agentic_config
 
 
 class TestRAGAgentDependencies:
@@ -399,3 +402,155 @@ class TestRAGAgentSystemPrompt:
         assert "search_knowledge_base" in system_prompt.lower()
         assert "cite" in system_prompt.lower()
         assert "confidence" in system_prompt.lower()
+
+
+class TestRAGAgentGlobalConfigContamination:
+    """Regression tests for cross-request global-config contamination.
+
+    `RAGAgent.__init__()` currently mutates the module-level `config`
+    singleton when `llm_provider`/`llm_model` overrides are supplied. That
+    mutation persists across subsequent `RAGAgent` constructions and across
+    concurrent requests, so a later request that supplies no override
+    silently uses the previously-set provider/model instead of the env
+    default. These tests pin that behavior and will fail on `main` until
+    `__init__` stops mutating the global.
+    """
+
+    # Sentinel values used as the per-test baseline. Chosen to be distinct
+    # from any provider/model literal used by other tests in this file so
+    # the regression assertion is deterministic regardless of test order
+    # (earlier tests in this suite leak overrides like "ollama"/"llama2"
+    # into the global, which is itself a symptom of the bug under test).
+    BASELINE_PROVIDER = "openai"
+    BASELINE_MODEL = "regression-baseline-sentinel"
+
+    @pytest.fixture(autouse=True)
+    def _force_known_baseline(self):
+        """Force the global config to a known baseline before each test.
+
+        Without this, the order-dependent state left behind by earlier
+        tests would let the regression assertions pass by accident
+        whenever a previous test happened to pollute the global with
+        the same override values used here.
+        """
+        original_provider = agentic_config.llm_provider
+        original_model = agentic_config.llm_model
+        agentic_config.llm_provider = self.BASELINE_PROVIDER
+        agentic_config.llm_model = self.BASELINE_MODEL
+        try:
+            yield
+        finally:
+            agentic_config.llm_provider = original_provider
+            agentic_config.llm_model = original_model
+
+    @patch("llmaven.agentic.agent.rag_agent.create_llm_model")
+    @patch("llmaven.agentic.agent.rag_agent.Agent")
+    @patch("llmaven.agentic.agent.rag_agent.HybridSearcher")
+    def test_init_does_not_mutate_global_config(
+        self, mock_searcher_cls, mock_agent_cls, mock_create_llm
+    ):
+        """Constructing a RAGAgent with overrides must not change the global config.
+
+        After RAGAgent(llm_provider=..., llm_model=...) returns, the
+        module-level `config` should still hold the values it had before the
+        call (the env-driven default). Today it does NOT — `__init__` writes
+        to `config.llm_provider` / `config.llm_model` directly, so a
+        subsequent default-construction silently picks up the override.
+        """
+        mock_searcher_cls.return_value = Mock()
+        mock_agent_cls.return_value = Mock()
+        mock_create_llm.return_value = Mock()
+
+        baseline_provider = agentic_config.llm_provider
+        baseline_model = agentic_config.llm_model
+
+        RAGAgent(llm_provider="ollama", llm_model="llama2")
+
+        # The bug: these two assertions fail on `main` because __init__
+        # mutated the singleton instead of using a local override.
+        assert agentic_config.llm_provider == baseline_provider, (
+            "RAGAgent.__init__ mutated the global config.llm_provider; "
+            f"expected {baseline_provider!r}, got {agentic_config.llm_provider!r}"
+        )
+        assert agentic_config.llm_model == baseline_model, (
+            "RAGAgent.__init__ mutated the global config.llm_model; "
+            f"expected {baseline_model!r}, got {agentic_config.llm_model!r}"
+        )
+
+    @patch("llmaven.agentic.agent.rag_agent.create_llm_model")
+    @patch("llmaven.agentic.agent.rag_agent.Agent")
+    @patch("llmaven.agentic.agent.rag_agent.HybridSearcher")
+    def test_default_construction_after_override_uses_env_default(
+        self, mock_searcher_cls, mock_agent_cls, mock_create_llm
+    ):
+        """A no-override RAGAgent built after an override must use the env default.
+
+        Demonstrates the cross-request contamination scenario from the
+        endpoint layer: request 1 supplies overrides, request 2 supplies
+        none — request 2's factory call should still see the env default.
+        """
+        mock_searcher_cls.return_value = Mock()
+        mock_agent_cls.return_value = Mock()
+        mock_create_llm.return_value = Mock()
+
+        baseline_provider = agentic_config.llm_provider
+        baseline_model = agentic_config.llm_model
+
+        # Simulate request 1 (with overrides) then request 2 (no overrides).
+        RAGAgent(llm_provider="ollama", llm_model="llama2")
+        RAGAgent()
+
+        # The second construction did not pass overrides, so the global
+        # config seen by its create_llm_model() call should still be the
+        # env-driven baseline. On `main` the global has been clobbered to
+        # "ollama"/"llama2" and stays that way.
+        assert agentic_config.llm_provider == baseline_provider, (
+            "Global provider leaked from a previous RAGAgent override; "
+            f"expected {baseline_provider!r}, got {agentic_config.llm_provider!r}"
+        )
+        assert agentic_config.llm_model == baseline_model, (
+            "Global model leaked from a previous RAGAgent override; "
+            f"expected {baseline_model!r}, got {agentic_config.llm_model!r}"
+        )
+
+    @patch("llmaven.agentic.agent.rag_agent.create_llm_model")
+    @patch("llmaven.agentic.agent.rag_agent.Agent")
+    @patch("llmaven.agentic.agent.rag_agent.HybridSearcher")
+    @pytest.mark.asyncio
+    async def test_concurrent_init_does_not_corrupt_global_config(
+        self, mock_searcher_cls, mock_agent_cls, mock_create_llm
+    ):
+        """Concurrent RAGAgent constructions must not leave the global mutated.
+
+        Fires N concurrent constructions with distinct overrides. After they
+        all complete, the global `config` should be unchanged from its
+        pre-test baseline. Today it ends up holding whichever override
+        happened to write last.
+        """
+        mock_searcher_cls.return_value = Mock()
+        mock_agent_cls.return_value = Mock()
+        mock_create_llm.return_value = Mock()
+
+        baseline_provider = agentic_config.llm_provider
+        baseline_model = agentic_config.llm_model
+
+        async def _build(provider: str, model: str) -> None:
+            # RAGAgent.__init__ is sync; wrap so we can gather it.
+            RAGAgent(llm_provider=provider, llm_model=model)
+
+        overrides = [
+            ("ollama", "llama2"),
+            ("huggingface", "mistral-7b"),
+            ("litellm", "claude-3"),
+            ("ollama", "phi-3"),
+        ]
+        await asyncio.gather(*(_build(p, m) for p, m in overrides))
+
+        assert agentic_config.llm_provider == baseline_provider, (
+            "Concurrent RAGAgent constructions corrupted global llm_provider; "
+            f"expected {baseline_provider!r}, got {agentic_config.llm_provider!r}"
+        )
+        assert agentic_config.llm_model == baseline_model, (
+            "Concurrent RAGAgent constructions corrupted global llm_model; "
+            f"expected {baseline_model!r}, got {agentic_config.llm_model!r}"
+        )

--- a/tests/v1/test_agentic_endpoints.py
+++ b/tests/v1/test_agentic_endpoints.py
@@ -13,6 +13,7 @@ from llmaven.main import app
 from llmaven.agentic.search.models import SearchResult
 from llmaven.agentic.agent.models import RAGResponse, Citation
 from llmaven.agentic.exceptions import AgenticRAGError
+from llmaven.agentic.settings import config as agentic_config
 
 client = TestClient(app)
 
@@ -411,3 +412,96 @@ class TestAgenticEndpointsIntegration:
         data = response.json()
         assert len(data["citations"]) == 3
         assert data["sources_used"] == 3
+
+
+class TestAgenticChatGlobalConfigContamination:
+    """Cross-request contamination via /v1/agentic/chat.
+
+    The chat endpoint constructs a fresh `RAGAgent` per request and
+    forwards user-controlled `llm_provider`/`llm_model` straight in.
+    `RAGAgent.__init__` writes those values into the module-level
+    `agentic_config` singleton, so a *subsequent* request that supplies
+    no overrides silently routes through the previous request's provider.
+
+    These tests deliberately mock at the layer **below** `RAGAgent`
+    (`create_llm_model`, `HybridSearcher`, `Agent`) so the real
+    `RAGAgent.__init__` runs end-to-end through the FastAPI handler.
+    """
+
+    # Sentinel baseline distinct from any string used elsewhere in the
+    # suite, so the assertion is invariant to test ordering even when
+    # earlier tests leak overrides into the global singleton.
+    BASELINE_PROVIDER = "openai"
+    BASELINE_MODEL = "regression-baseline-sentinel"
+
+    @pytest.fixture(autouse=True)
+    def _force_known_baseline(self):
+        original_provider = agentic_config.llm_provider
+        original_model = agentic_config.llm_model
+        agentic_config.llm_provider = self.BASELINE_PROVIDER
+        agentic_config.llm_model = self.BASELINE_MODEL
+        try:
+            yield
+        finally:
+            agentic_config.llm_provider = original_provider
+            agentic_config.llm_model = original_model
+
+    @patch("llmaven.agentic.agent.rag_agent.create_llm_model")
+    @patch("llmaven.agentic.agent.rag_agent.Agent")
+    @patch("llmaven.agentic.agent.rag_agent.HybridSearcher")
+    def test_chat_request_does_not_leak_provider_to_subsequent_request(
+        self, mock_searcher_cls, mock_agent_cls, mock_create_llm
+    ):
+        """Two sequential POSTs: request 1 has overrides, request 2 does not.
+
+        Request 2 must be served using the env-default provider/model. On
+        `main` the global config has been clobbered by request 1, so
+        request 2's `RAGAgent.__init__` sees the leaked override.
+        """
+        mock_searcher_cls.return_value = Mock()
+        # pydantic-ai Agent.run() returns AgentRunResult with .output attribute,
+        # which RAGAgent.run() unwraps before returning to the endpoint.
+        mock_run_result = Mock()
+        mock_run_result.output = RAGResponse(
+            answer="ok",
+            citations=[],
+            confidence=0.0,
+            sources_used=0,
+        )
+        mock_agent_instance = Mock()
+        mock_agent_instance.run = AsyncMock(return_value=mock_run_result)
+        mock_agent_cls.return_value = mock_agent_instance
+        mock_create_llm.return_value = Mock()
+
+        baseline_provider = agentic_config.llm_provider
+        baseline_model = agentic_config.llm_model
+
+        # Request 1 — supplies overrides.
+        resp1 = client.post(
+            "/v1/agentic/chat",
+            json={
+                "query": "first",
+                "llm_provider": "ollama",
+                "llm_model": "llama2",
+            },
+        )
+        assert resp1.status_code == 200
+
+        # Request 2 — no overrides, expected to use the env default.
+        resp2 = client.post("/v1/agentic/chat", json={"query": "second"})
+        assert resp2.status_code == 200
+
+        # After both requests, the global must still equal the baseline.
+        # Today it equals ("ollama", "llama2") because request 1 leaked.
+        assert agentic_config.llm_provider == baseline_provider, (
+            "Provider leaked across requests: request 1's override "
+            "persisted in the global config singleton after the response "
+            f"was returned (expected {baseline_provider!r}, "
+            f"got {agentic_config.llm_provider!r}). Subsequent requests "
+            "without an override will silently route to the wrong provider."
+        )
+        assert agentic_config.llm_model == baseline_model, (
+            "Model leaked across requests: request 1's override persisted "
+            f"in the global config singleton (expected {baseline_model!r}, "
+            f"got {agentic_config.llm_model!r})."
+        )


### PR DESCRIPTION
## Summary

Fixes #142. `RAGAgent.__init__` no longer mutates the module-level `agentic_config` singleton. Per-call `llm_provider` / `llm_model` overrides are now threaded explicitly through `create_llm_model()` into each provider helper — matching the dependency-injection pattern already used by pydantic-ai's own `Agent(model=...)`, the OpenAI/Anthropic SDKs, and LangChain's `Runnable` config.

The four regression tests landed in #143 (cherry-picked into this branch as `9c270c4`) now pass alongside the existing suite.

## Why this approach

The "read defaults from a settings singleton, accept per-call overrides as function arguments, never write back" pattern is the consensus across the libraries this repo already depends on:

- **pydantic-ai** — `Agent(model=...)`, no global mutation.
- **LangChain Runnables** — `RunnableConfig` is per-invocation, never mutates the chain.
- **OpenAI / Anthropic SDKs** — model is a per-call kwarg.
- **FastAPI Settings tutorial (official)** — `Depends(get_settings)`; the singleton is read-only.
- **Pydantic Settings docs** — mutating a `BaseSettings` instance is explicitly discouraged; use `model_copy(update={...})` for variants.

Alternatives considered and rejected:

- **`ContextVar`** — correct for request-scoped state across many call sites; overkill here for a single explicit param.
- **`frozen=True` on `AgenticConfig`** — would catch the bug, but breaks any legitimate runtime config update; bigger blast radius.
- **Full `Depends(get_settings)` migration** — the right move *eventually* for the whole config singleton, but a much larger refactor than #142 deserves. Worth a separate issue if of interest.

## Changes

| File | Change |
|---|---|
| `src/llmaven/agentic/providers/factory.py` | `create_llm_model(provider=None, model=None)` resolves defaults from `config`; each `_create_*` helper now takes `model: str` explicitly. |
| `src/llmaven/agentic/agent/rag_agent.py` | Removed the two `config.llm_provider = …` / `config.llm_model = …` writes. Effective provider/model are computed locally for logging and passed to `create_llm_model(...)`. |
| `tests/agentic/test_providers.py` | Updated direct calls to private helpers to pass `model` explicitly, mirroring production. |

Diff is small (~50 lines net) and surgical. No behavior change for env-var-default callers; no new dependencies.

## Test plan

- [x] Four regression tests from #143 pass on this branch:
      `tests/agentic/test_rag_agent.py::TestRAGAgentGlobalConfigContamination` (3 tests)
      `tests/v1/test_agentic_endpoints.py::TestAgenticChatGlobalConfigContamination` (1 test)
- [x] `tests/agentic/test_providers.py` — all 17 tests pass after updating the direct-helper calls.
- [x] `tests/agentic/test_rag_agent.py` — all 30 tests pass.
- [x] `tests/v1/test_agentic_endpoints.py` — all 10 tests pass.
- [x] `pre-commit run` clean on changed files.
- [x] 6 pre-existing failures in `tests/test_generator.py`, `tests/test_retriever.py`, `tests/infrastructure/test_cli_extract.py` are present on `main` as well — unrelated to this change.

Fixes #142
