### PR TITLE
Fix issue 17: add Azure Blob Storage support for document ingestion

### DIFF
--- a/src/llmaven/agentic/ingestion/pipeline.py
+++ b/src/llmaven/agentic/ingestion/pipeline.py
@@ -142,6 +142,9 @@ class IngestionPipeline:
         documents = []
 
         for directory in directories:
+            if directory.startswith("az://"):
+                documents.extend(self._load_from_azure(directory))
+                continue
             dir_path = Path(directory)
             if not dir_path.exists():
                 raise IngestionError(f"Directory does not exist: {directory}")
@@ -176,6 +179,74 @@ class IngestionPipeline:
                         # Continue processing other files if one fails
                         continue
 
+        return documents
+    
+    def _load_from_azure(self, uri: str) -> list[dict[str, Any]]:
+        """Load documents from Azure Blob Storage.
+
+        Args:
+        uri: Azure Blob URI in the format az://container-name/optional-prefix
+
+        Returns:
+        List of document dicts with 'file_path' and 'content' keys
+
+        Raises:
+        IngestionError: If Azure connection or blob listing fails
+        """
+        # Parse az://container/prefix
+        path = uri[len("az://"):]
+        parts = path.split("/", 1)
+        container_name = parts[0]
+        prefix = parts[1] if len(parts) > 1 else ""
+
+        try:
+            from azure.storage.blob import BlobServiceClient
+            from azure.identity import DefaultAzureCredential
+
+            if config.azure_blob_connection_string:
+                client = BlobServiceClient.from_connection_string(
+                    config.azure_blob_connection_string
+                )
+            elif config.azure_blob_account_url:
+                client = BlobServiceClient(
+                    account_url=config.azure_blob_account_url,
+                    credential=DefaultAzureCredential(),
+                )
+            else:
+                raise IngestionError(
+                    "Azure Blob Storage requires either AGENTIC_AZURE_BLOB_ACCOUNT_URL "
+                    "or AGENTIC_AZURE_BLOB_CONNECTION_STRING in environment."
+                )
+        except ImportError as e:
+            raise IngestionError(
+                f"azure-storage-blob and azure-identity are required for Azure ingestion: {e}"
+            ) from e
+
+        documents = []
+        container_client = client.get_container_client(container_name)
+
+        try:
+            blobs = container_client.list_blobs(name_starts_with=prefix or None)
+        except Exception as e:
+            raise IngestionError(f"Failed to list blobs in '{container_name}': {e}") from e
+
+        for blob in blobs:
+            blob_name: str = blob.name
+            suffix = Path(blob_name).suffix.lower()
+            if suffix not in self.SUPPORTED_EXTENSIONS:
+                continue
+            try:
+                blob_client = container_client.get_blob_client(blob_name)
+                data = blob_client.download_blob().readall()
+                content = data if suffix == ".pdf" else data.decode("utf-8", errors="ignore")
+                documents.append(
+                {
+                "file_path": f"az://{container_name}/{blob_name}",
+                "content": content,
+                }
+                )
+            except Exception:
+                continue
         return documents
 
     def parse(self, document: dict[str, Any]) -> dict[str, Any]:

--- a/src/llmaven/agentic/ingestion/pipeline.py
+++ b/src/llmaven/agentic/ingestion/pipeline.py
@@ -180,7 +180,7 @@ class IngestionPipeline:
                         continue
 
         return documents
-    
+
     def _load_from_azure(self, uri: str) -> list[dict[str, Any]]:
         """Load documents from Azure Blob Storage.
 
@@ -194,7 +194,7 @@ class IngestionPipeline:
         IngestionError: If Azure connection or blob listing fails
         """
         # Parse az://container/prefix
-        path = uri[len("az://"):]
+        path = uri[len("az://") :]
         parts = path.split("/", 1)
         container_name = parts[0]
         prefix = parts[1] if len(parts) > 1 else ""
@@ -228,7 +228,9 @@ class IngestionPipeline:
         try:
             blobs = container_client.list_blobs(name_starts_with=prefix or None)
         except Exception as e:
-            raise IngestionError(f"Failed to list blobs in '{container_name}': {e}") from e
+            raise IngestionError(
+                f"Failed to list blobs in '{container_name}': {e}"
+            ) from e
 
         for blob in blobs:
             blob_name: str = blob.name
@@ -238,12 +240,14 @@ class IngestionPipeline:
             try:
                 blob_client = container_client.get_blob_client(blob_name)
                 data = blob_client.download_blob().readall()
-                content = data if suffix == ".pdf" else data.decode("utf-8", errors="ignore")
+                content = (
+                    data if suffix == ".pdf" else data.decode("utf-8", errors="ignore")
+                )
                 documents.append(
-                {
-                "file_path": f"az://{container_name}/{blob_name}",
-                "content": content,
-                }
+                    {
+                        "file_path": f"az://{container_name}/{blob_name}",
+                        "content": content,
+                    }
                 )
             except Exception:
                 continue

--- a/src/llmaven/agentic/settings.py
+++ b/src/llmaven/agentic/settings.py
@@ -35,6 +35,8 @@ class AgenticConfig(BaseSettings):
         enable_rerank: Whether to enable ColBERT reranking (default: True)
         prefetch_top_k: Number of candidates from each prefetch method (default: 20)
         final_top_k: Final number of results to return (default: 5)
+        azure_blob_account_url: Azure Blob Storage account URL (e.g. https://myaccount.blob.core.windows.net)
+        azure_blob_connection_string: Azure Blob Storage connection string (alternative to account URL)
     """
 
     model_config = SettingsConfigDict(
@@ -88,6 +90,9 @@ class AgenticConfig(BaseSettings):
         default=5, gt=0, description="Final number of results to return"
     )
 
+    # Load data from Azure 
+    azure_blob_account_url: str | None = None # e.g. https://myaccount.blob.core.windows.net
+    azure_blob_connection_string: str | None = None # fallback auth
 
 # Global configuration instance
 config = AgenticConfig()

--- a/src/llmaven/agentic/settings.py
+++ b/src/llmaven/agentic/settings.py
@@ -90,9 +90,12 @@ class AgenticConfig(BaseSettings):
         default=5, gt=0, description="Final number of results to return"
     )
 
-    # Load data from Azure 
-    azure_blob_account_url: str | None = None # e.g. https://myaccount.blob.core.windows.net
-    azure_blob_connection_string: str | None = None # fallback auth
+    # Load data from Azure
+    azure_blob_account_url: str | None = (
+        None  # e.g. https://myaccount.blob.core.windows.net
+    )
+    azure_blob_connection_string: str | None = None  # fallback auth
+
 
 # Global configuration instance
 config = AgenticConfig()


### PR DESCRIPTION
## Summary

- Modified settings.py and pipeline.py
- pipeline.py - checks for az:// URIs and directs them to a new method _load_from_azure(). Local paths will work unchanged.
- settings.py - added 2 fields azure_blob_account_url and azure_blob_connection_string and their docstrings. 

## Notes for reviewer

Is it possible to share a test storage account for me to perform end-to-end test?

I have been able to run the RAG pipeline on my local by adding Rubin Observatory sample articles from internet and using my current company's LLM credentials. Here is a screenshot. 



<img width="1280" height="713" alt="image" src="https://github.com/user-attachments/assets/a6c20ff2-7655-4cd6-91f7-b761f8a638fd" />
<img width="1280" height="466" alt="image" src="https://github.com/user-attachments/assets/5d932dae-b522-42e4-bc51-35541dd1bfe0" />


