### PR TITLE
Prompt enhancements - rag_agent.py and config.py

### DIFF
--- a/src/llmaven/agentic/agent/rag_agent.py
+++ b/src/llmaven/agentic/agent/rag_agent.py
@@ -118,14 +118,16 @@ class RAGAgent:
         Returns:
             System prompt string
         """
-        return """You are a helpful AI assistant with access to a knowledge base.
-
+        return """You are an expert AI assistant specializing in astrophysics, with deep knowledge of the Rubin Observatory and the Legacy Survey of Space and Time (LSST). You have access to a scientific knowledge base of domain-specific literature and documentation.
 When answering questions:
 1. Use the search_knowledge_base tool to find relevant information
 2. Synthesize information from multiple sources when available
 3. Always cite your sources with relevant quotes
 4. Provide a confidence score based on the quality and quantity of sources
-5. If you don't find relevant information, say so honestly
+5. Only use information found in the search results to construct your answer. If you don't find relevant information, say so honestly
+6. If search results have low relevance scores/are partially relevant or don't directly address the question, set confidence below 0.5, explain what you did find, and ask the user if they'd like you to try a different search angle.
+7. When discussing scientific concepts, be precise with terminology — use correct units, instrument names (e.g. LSSTCam, LATISS), survey parameters, and catalog names (e.g. Object, Source, DiaObject) as they appear in the literature.
+8. If a question is ambiguous in the context of Rubin/LSST (e.g. "magnitude limit" could refer to different filters or survey depths), briefly clarify the assumption you're making.
 
 Your responses should be accurate, well-structured, and backed by citations.
 """

--- a/src/llmaven/frontend/config.py
+++ b/src/llmaven/frontend/config.py
@@ -68,9 +68,16 @@ def format_prompt(context: str, question: str) -> str:
         Formatted prompt for the generation model
     """
     return textwrap.dedent(f"""
-    You are an astrophysics expert with a focus on the Rubin telescope project
-    (formerly known as Large Synoptic Survey Telescope - LSST). Please answer the
-    question on astrophysics based on the following context:
+    You are an astrophysics expert with a focus on the Rubin Observatory project
+    (formerly known as Large Synoptic Survey Telescope - LSST). Answer the question
+    using ONLY the information provided in the context below. Do not rely on prior
+    knowledge or introduce facts not present in the context.
+
+    If the context does not contain enough information to answer the question fully,
+    say so explicitly rather than guessing. Where relevant, quote or reference
+    specific parts of the context to support your answer.
+
+    Context:
 
     {context}
 


### PR DESCRIPTION
## Summary

**Improve LLM prompts for domain specificity and grounding**

**Changes:**
- `rag_agent.py`: Updated system prompt to establish the agent as a Rubin Observatory/LSST specialist. Added instructions to use precise scientific terminology (instrument names, catalog names, units) and to clarify ambiguous Rubin/LSST assumptions before answering.
- `frontend/config.py`: Updated `format_prompt()` to explicitly ground the model in the retrieved context — instructs the model to answer using only the provided context, acknowledge gaps rather than guessing, and quote relevant parts of the context in its response.

**Testing:**
Not locally tested — pixi was previously working on my machine - 

<img width="1280" height="713" alt="image" src="https://github.com/user-attachments/assets/fc2ba0cd-ac23-4212-b79f-d948a52facb6" />


but is currently blocked by office laptop settings. I'm trying to find a workaround.

<img width="377" height="115" alt="image" src="https://github.com/user-attachments/assets/dbeb45d5-b3f0-4152-b98e-537d25a963f4" />



