### PR TITLE
Update Dockerfile to use litellm v1.91.1

### DIFF
--- a/docker/dockerfiles/litellm.dockerfile
+++ b/docker/dockerfiles/litellm.dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/berriai/litellm:v1.82.3-stable
+FROM ghcr.io/berriai/litellm:v1.91.1
 
 RUN pip install --no-cache-dir "mlflow==3.6.0" "azure-storage-blob>=12.0.0,<13" "azure-identity>=1.0.0,<2"


### PR DESCRIPTION
This pull request updates the base image version used in the `litellm.dockerfile` to ensure compatibility with newer features and bug fixes.

Dependency updates:

* Updated the base image in `docker/dockerfiles/litellm.dockerfile` from `ghcr.io/berriai/litellm:v1.82.3-stable` to `ghcr.io/berriai/litellm:v1.91.1` to use a more recent and stable version.